### PR TITLE
Fix toggleDone: inbox badge + checklist badge now update everywhere

### DIFF
--- a/index.html
+++ b/index.html
@@ -1554,7 +1554,7 @@ function toggleDone(id){
   t.status=t.status==='done'?'todo':'done';
   t.completedAt=t.status==='done'?new Date().toISOString():null;
   if(t.status==='done'){t.isT3=false;t.t3s=null;_logContextSwitch(t.category);}
-  save();refresh();
+  save();refresh();updIBadge();updateChecklistBadge();
 }
 
 function mvB(id,b){const t=S.tasks.find(x=>x.id===id);if(!t)return;t.bucket=b;save();refresh();}


### PR DESCRIPTION
**Bug:** `toggleDone()` called `save()` + `refresh()` but not `updIBadge()` or `updateChecklistBadge()`. The inbox count in the sidebar and the daily checklist badge stayed stale whenever you marked a task done from Buckets, All Tasks, Goals, Focus, Eisenhower, or any view other than Capture.

**Fix:** Added both calls to `toggleDone` so every mark-done updates all live counters immediately regardless of which view you're on.

https://claude.ai/code/session_01N9FtqGWBtrMMyyN5tJvGrN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9FtqGWBtrMMyyN5tJvGrN)_