### PR TITLE
Fix JS syntax error that broke the app on all devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1587,9 +1587,9 @@ function _renderChecklistEditor(){
   const done=_editChecklist.filter(x=>x.done).length;
   badge.textContent=_editChecklist.length?'('+done+'/'+_editChecklist.length+')':'';
   items.innerHTML=_editChecklist.map((c,i)=>'<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'+
-    '<div class="ck '+(c.done?'on':'')+'" onclick="_toggleCLItem(''+c.id+'')" style="width:18px;height:18px;flex-shrink:0;">'+(c.done?'<span style="color:#fff;font-size:9px;">✓</span>':'')+'</div>'+
+    '<div class="ck '+(c.done?'on':'')+'" onclick="_toggleCLItem(\''+c.id+'\')" style="width:18px;height:18px;flex-shrink:0;">'+(c.done?'<span style="color:#fff;font-size:9px;">✓</span>':'')+'</div>'+
     '<span style="flex:1;font-size:13px;'+(c.done?'text-decoration:line-through;color:var(--muted)':'')+'">'+c.text+'</span>'+
-    '<button class="btn bg sm" style="padding:2px 6px;font-size:11px;" onclick="_removeCLItem(''+c.id+'')">×</button>'+
+    '<button class="btn bg sm" style="padding:2px 6px;font-size:11px;" onclick="_removeCLItem(\''+c.id+'\')">×</button>'+
     '</div>').join('');
 }
 function addChecklistItem(){

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260510-213122';
+const CACHE = 'task-os-20260513-074719';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',


### PR DESCRIPTION
## Critical bug fix

Unescaped single quotes in `_renderChecklistEditor()` caused a `SyntaxError` that prevented the **entire JS script from loading** — making the app completely non-functional on every device.

### Root cause
```js
// BROKEN — the ' before and after c.id are JS string delimiters, not HTML chars
'" onclick="_toggleCLItem(''+c.id+'')" ...'

// FIXED — escaped so they're literal chars inside the JS string
'" onclick="_toggleCLItem(\''+c.id+'\')" ...'
```

The same bug affected `_removeCLItem` on the same line.

### Also
- Bumped service worker cache key (`task-os-20260513-074719`) so phones immediately pick up the fix instead of loading the broken cached version.

https://claude.ai/code/session_01Hg3yAXazyH95vprCzMWYjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg3yAXazyH95vprCzMWYjv)_