### PR TITLE
Expand Work nav section by default so Givelink OS is always visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -2295,6 +2295,7 @@ function showConfirm(msg,cb,{okLabel='Delete',icon='⚠️',danger=true}={}){
   btn.className=danger?'btn bd':'btn bp';
   _confirmCb=cb;
   document.getElementById('confirm-modal').classList.remove('hidden');
+  document.body.classList.add('modal-open');
 }
 
 // ── PROMPT MODAL (iOS-PWA-safe replacement for window.prompt) ──
@@ -2306,6 +2307,7 @@ function showPrompt(label,cb,{placeholder='',value='',okLabel='Save'}={}){
   document.getElementById('prompt-ok-btn').textContent=okLabel;
   _promptCb=cb;
   document.getElementById('prompt-modal').classList.remove('hidden');
+  document.body.classList.add('modal-open');
   setTimeout(()=>{inp.focus();inp.select();},60);
 }
 function _promptOK(){
@@ -2316,7 +2318,7 @@ function _promptOK(){
 }
 
 // ── AI LOADING SPINNERS ───────────────────────────────────────
-function _showAiLoader(title='AI thinking…'){const t=document.getElementById('ai-out-title');if(t&&title)t.textContent=title;const b=document.getElementById('ai-out-body');if(b)b.innerHTML='<div class="skel" style="width:92%"></div><div class="skel" style="width:100%"></div><div class="skel" style="width:76%"></div><div class="skel" style="width:88%"></div><div class="skel" style="width:62%"></div>';document.getElementById('ai-out-modal').classList.remove('hidden');}
+function _showAiLoader(title='AI thinking…'){const t=document.getElementById('ai-out-title');if(t&&title)t.textContent=title;const b=document.getElementById('ai-out-body');if(b)b.innerHTML='<div class="skel" style="width:92%"></div><div class="skel" style="width:100%"></div><div class="skel" style="width:76%"></div><div class="skel" style="width:88%"></div><div class="skel" style="width:62%"></div>';document.getElementById('ai-out-modal').classList.remove('hidden');document.body.classList.add('modal-open');}
 function _btnLoading(btn,loading){
   if(!btn)return;
   if(loading){btn._origText=btn.innerHTML;btn.innerHTML='<span class="spin-icon">⟳</span> Working...';btn.disabled=true;}
@@ -2326,6 +2328,7 @@ function _btnLoading(btn,loading){
 // ── GLOBAL SEARCH ─────────────────────────────────────────────
 function openGlobalSearch(){
   document.getElementById('gsearch-modal').classList.remove('hidden');
+  document.body.classList.add('modal-open');
   setTimeout(()=>document.getElementById('gsearch-input')?.focus(),50);
 }
 function _gsearch(){
@@ -3389,7 +3392,7 @@ function closeM(id){
   const el=document.getElementById(id);
   if(el){_releaseFocus(el);el.classList.add('hidden');}
   editT=null;editG=null;
-  document.body.classList.remove('modal-open');
+  if(!document.querySelector('.mo:not(.hidden)'))document.body.classList.remove('modal-open');
 }
 function openM(id){
   const el=document.getElementById(id);

--- a/index.html
+++ b/index.html
@@ -579,8 +579,8 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
   <div class="ni" data-v="bucketlist" onclick="nav('bucketlist')"><span class="ni-ic">🌍</span>Bucket List</div>
   <div class="ni" data-v="wishlist" onclick="nav('wishlist')"><span class="ni-ic">🛒</span>Wishlist</div>
   </div>
-  <div class="ns-group collapsed" data-ns="work">
-  <span class="ns" onclick="_toggleNsGroup(this)">Work<span class="ns-arrow">▸</span></span>
+  <div class="ns-group" data-ns="work">
+  <span class="ns" onclick="_toggleNsGroup(this)">Work<span class="ns-arrow">▾</span></span>
   <div class="ni" data-v="givelink-dash" onclick="nav('givelink-dash')"><span class="ni-ic">🟣</span>Givelink OS</div>
   <div class="ni" data-v="content" onclick="nav('content')"><span class="ni-ic">✍️</span>Content Pipeline</div>
   <div class="ni" data-v="projects" onclick="nav('projects')"><span class="ni-ic">🚀</span>Projects</div>


### PR DESCRIPTION
## Problem
The "Work" nav section was `collapsed` by default, so Givelink OS, Content Pipeline, Projects, and AI Lab were all hidden behind a collapsed group header — users had to click "Work ▸" to reveal them first.

## Fix
Removed `collapsed` from the Work section so it's expanded on first load. The existing localStorage persistence still respects user preferences — if someone later collapses it, that choice is saved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg3yAXazyH95vprCzMWYjv)_