### PR TITLE
Enable Supabase cloud sync in production (CSP)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.anthropic.com https://hooks.slack.com https://ntfy.sh https://readwise.io https://api.notion.com; font-src 'self'; frame-ancestors 'none';" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.anthropic.com https://hooks.slack.com https://ntfy.sh https://readwise.io https://api.notion.com https://*.supabase.co wss://*.supabase.co; font-src 'self'; frame-ancestors 'none';" }
       ]
     },
     {


### PR DESCRIPTION
The app already ships an offline-first Supabase cloud-sync feature (Settings → Cloud Sync) that talks to the Supabase REST/Auth API via `fetch`, but the production Content-Security-Policy's `connect-src` didn't allow `*.supabase.co`, so sync silently failed online.

Adds `https://*.supabase.co` (and `wss://*.supabase.co` for realtime) to `connect-src`. No app code change — this just unblocks the existing feature so desktop ↔ mobile sync works once the user configures their Supabase project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_