### PR TITLE
Bump service-worker cache to force PWA update

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260530';
+const CACHE = 'task-os-20260704';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',


### PR DESCRIPTION
Users were still seeing the pre-redesign UI because the service worker's cache name never changed across deploys, so installed PWAs / cached browsers kept serving stale assets. Bumping `CACHE` invalidates the old cache; the existing `skipWaiting` + `clients.claim` + activate-cleanup wipes old caches and serves the current build on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_