### PR TITLE
Make it fully mobile-friendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@ hr{border:none;border-top:1px solid var(--border);margin:18px 0;}
 .cb{background:rgba(247,131,172,.15);color:var(--cb);}
 .co{background:rgba(134,142,150,.15);color:var(--co);}
 /* BUTTONS */
-.btn{padding:9px 16px;border-radius:9px;border:none;cursor:pointer;font-size:13px;font-weight:600;transition:all .12s;display:inline-flex;align-items:center;gap:5px;}
+.btn{padding:9px 16px;border-radius:9px;border:none;cursor:pointer;font-size:13px;font-weight:600;transition:all .12s;display:inline-flex;align-items:center;gap:5px;white-space:nowrap;}
 .bp{background:var(--brand-gradient);color:#fff;box-shadow:0 4px 16px -4px rgba(139,124,255,.5);}.bp:hover{filter:brightness(1.07);box-shadow:0 6px 22px -4px rgba(139,124,255,.6);}
 .btn:active{transform:scale(.96);}
 .bg{background:transparent;color:var(--muted);border:1px solid var(--border);}.bg:hover{background:var(--surface2);color:var(--text);}
@@ -192,7 +192,8 @@ select.fc option{background:var(--surface2);}
 .sl2{font-size:10px;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.4px;margin-bottom:7px;}
 .se{color:var(--muted);font-size:12px;text-align:center;padding:14px 0;cursor:pointer;}.se:hover{color:var(--text);}
 /* BUCKETS */
-.bgrid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;align-items:start;}
+.bgrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px;align-items:start;}
+.bc{min-width:0;}
 .bc{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:13px;min-height:180px;}
 .bh{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;padding-bottom:9px;border-bottom:1px solid var(--border);}
 .bt{font-size:13px;font-weight:600;display:flex;align-items:center;gap:5px;}
@@ -282,7 +283,7 @@ kbd{background:var(--surface2);border:1px solid var(--border);border-bottom-widt
 .eng-btn:hover,.eng-btn.sel{border-color:var(--accent);background:rgba(88,166,255,.1);color:var(--accent);}
 .focus-rec{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:14px;margin-bottom:9px;display:flex;align-items:flex-start;gap:10px;}
 .focus-num{width:26px;height:26px;background:var(--accent);color:#000;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;flex-shrink:0;margin-top:2px;}
-.goal-dash{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:22px;}
+.goal-dash{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin-bottom:22px;}
 .gdc{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:12px;cursor:pointer;transition:border-color .12s;}.gdc:hover{border-color:var(--accent);}
 .gdc-title{font-size:12px;font-weight:600;margin-bottom:6px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;}
 .gdc-row{display:flex;justify-content:space-between;align-items:center;margin-bottom:5px;}
@@ -304,7 +305,8 @@ kbd{background:var(--surface2);border:1px solid var(--border);border-bottom-widt
   .sidebar.open{left:0;}
   .s-ov.open{z-index:205;}
   .s-ov.open{display:block;}
-  body{height:auto;overflow:auto;}
+  body{height:auto;overflow-y:auto;overflow-x:hidden;}
+  .main{max-width:100%;overflow-x:hidden;}
   .main{padding:60px 14px 72px;overflow-y:visible;height:auto;}
   .stats{grid-template-columns:repeat(2,1fr);}
   .bgrid{grid-template-columns:1fr;}
@@ -331,7 +333,7 @@ kbd{background:var(--surface2);border:1px solid var(--border);border-bottom-widt
   /* Larger tap targets for checkboxes */
   .ck{width:28px;height:28px;min-width:28px;border-radius:6px;}
   /* Prevent iOS auto-zoom on input focus (requires font-size >= 16px) */
-  input,textarea,select,.fc,.capi,.sb,.cmdk-i{font-size:16px!important;}
+  input,textarea,select,.fc,.capi,.sb,.cmdk-i,.task-reply-input,.snooze-opt{font-size:16px!important;}
   /* Life OS 2-column grid on mobile */
   .los-grid{grid-template-columns:1fr 1fr;}
   /* Dashboard header: horizontal scroll instead of wrapping */
@@ -580,9 +582,9 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 .tband-counts b{font-size:21px;font-weight:700;font-variant-numeric:tabular-nums;display:block;letter-spacing:-.02em;}
 .tband-counts span{font-size:11px;color:var(--muted);}
 @media(max-width:640px){.tband{gap:18px;padding:14px 16px;}.tband-counts{margin-left:0;gap:18px;}.tband-div{display:none;}}
-.dash-grid{display:grid;grid-template-columns:1fr 1fr;gap:20px;align-items:start;}
-.dash-col-main,.dash-col-side{display:flex;flex-direction:column;gap:14px;}
-@media(max-width:900px){.dash-grid{grid-template-columns:1fr;}}
+.dash-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:20px;align-items:start;}
+.dash-col-main,.dash-col-side{display:flex;flex-direction:column;gap:14px;min-width:0;}
+@media(max-width:900px){.dash-grid{grid-template-columns:minmax(0,1fr);}}
 /* ── COMMAND-PALETTE CHIP (Superhuman ⌘K affordance) ─────────────── */
 .cmdk-chip{display:flex;align-items:center;gap:8px;width:calc(100% - 16px);margin:8px 8px 6px;padding:8px 11px;background:var(--surface2);border:1px solid var(--border);border-radius:10px;color:var(--muted);font-size:12.5px;font-weight:500;cursor:pointer;transition:border-color .12s,background .12s,box-shadow .12s;-webkit-tap-highlight-color:transparent;}
 .cmdk-chip:hover{border-color:var(--accent);color:var(--text);box-shadow:0 0 0 3px var(--accent-soft);}
@@ -612,7 +614,8 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 .tc-act:active{transform:scale(.9);}
 @media(hover:none){.tc-actions{display:none;}}
 /* ── SUPERHUMAN TWO-PANE READING VIEW (All Tasks) ────────────────── */
-.all-two-pane{display:grid;grid-template-columns:1fr;gap:18px;align-items:start;}
+.all-two-pane{display:grid;grid-template-columns:minmax(0,1fr);gap:18px;align-items:start;}
+#all-list{min-width:0;}
 @media(min-width:1000px){.all-two-pane{grid-template-columns:minmax(0,1.15fr) minmax(300px,.82fr);}}
 .reading-pane{position:sticky;top:6px;background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:18px 20px;max-height:calc(100vh - 78px);overflow-y:auto;box-shadow:0 1px 3px rgba(0,0,0,.05);}
 @media(max-width:999px){.reading-pane{display:none;}}
@@ -625,7 +628,7 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 .task-drawer.open .td-panel{transform:none;}
 .td-close{position:absolute;top:12px;right:14px;background:none;border:none;color:var(--muted);font-size:22px;cursor:pointer;line-height:1;padding:4px 9px;border-radius:7px;transition:background .12s,color .12s;}
 .td-close:hover{color:var(--text);background:var(--hover);}
-@media(max-width:768px){.task-drawer .td-panel{width:100%;max-width:100%;border-left:none;}}
+@media(max-width:768px){.task-drawer .td-panel{width:100%;max-width:100%;border-left:none;padding-top:max(52px,calc(env(safe-area-inset-top,0px) + 46px));padding-bottom:max(24px,calc(env(safe-area-inset-bottom,0px) + 16px));}.td-close{top:max(12px,env(safe-area-inset-top,12px));width:38px;height:38px;display:flex;align-items:center;justify-content:center;padding:0;background:var(--surface2);border:1px solid var(--border);font-size:20px;}}
 /* Reply-to-act box */
 .task-reply{display:flex;gap:7px;margin-top:16px;padding-top:14px;border-top:1px solid var(--border);}
 .task-reply-input{flex:1;min-width:0;background:var(--surface2);border:1px solid var(--border);border-radius:10px;padding:9px 12px;color:var(--text);font:inherit;font-size:13px;outline:none;transition:border-color .12s,box-shadow .12s;}
@@ -2576,6 +2579,7 @@ let _scrollPos={};
 function nav(v){
   _selTaskId=null;
   _closeFabDial();
+  if(document.getElementById('task-drawer')?.classList.contains('open'))closeTaskDrawer();
   const _prev=document.querySelector('.view.active');
   if(_prev)_scrollPos[_prev.id]={m:document.querySelector('.main')?.scrollTop||0,w:window.scrollY||0};
   localStorage.setItem('taskos_lastview',v);
@@ -8481,8 +8485,9 @@ function _taskDetailRefresh(id){
   if(document.getElementById('reading-pane')&&document.getElementById('v-all')?.classList.contains('active'))renderReadingPane(id);
 }
 // Click a task card outside All Tasks → open the drawer instead of the edit modal
+// (on mobile, All Tasks has no inline pane, so it uses the drawer too)
 document.addEventListener('click',function(e){
-  if(document.getElementById('v-all')?.classList.contains('active'))return; // All Tasks uses its inline pane
+  if(document.getElementById('v-all')?.classList.contains('active')&&window.innerWidth>=1000)return; // desktop All Tasks uses its inline pane
   const tc=e.target.closest('.tc[data-swipe-id]');
   if(!tc)return;
   if(e.target.closest('.ck')||e.target.closest('.tc-actions'))return;


### PR DESCRIPTION
Polishes this session's features (and the app overall) for phones.

## Fixes
- **No more sideways scroll.** Fixed a grid width-blowout (`grid-template-columns:1fr` expanding to content max-width) in `dash-grid`, `all-two-pane`, `bgrid`, `goal-dash` → `minmax(0,1fr)` with `min-width:0` columns, plus an `overflow-x:hidden` safety net on `body`/`.main` under 768px. Verified: none of dashboard / all / buckets / goals / capture / eisenhower / habits / wheel / okrs / review scroll horizontally.
- **Header buttons** no longer wrap to two lines (`.btn { white-space:nowrap }`) — they scroll in their row instead.
- **All Tasks on mobile** now opens the **task drawer** on tap (the inline reading pane is desktop-only) instead of the full edit modal — so reply-to-act + quick actions are available on phones.
- **Task drawer on mobile:** full-width, safe-area top/bottom insets, a larger visible close button, and it **closes on navigation** (it used to persist over the next view).
- **Inputs** (reply box, snooze picker) use 16px on mobile to stop iOS focus-zoom.

## Verification
Headless Chromium at 390×844: zero horizontal overflow across 10 views; drawer opens on tap and closes on nav; snooze renders as a bottom sheet; Process Mode and the ring band lay out cleanly; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_