### PR TITLE
Mobile Superhuman/Notion polish + fix load-time init bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,6 +297,8 @@ kbd{background:var(--surface2);border:1px solid var(--border);border-bottom-widt
 /* ── MOBILE ─────────────────────────────────────────────────── */
 .ham-btn{display:none;position:fixed;top:max(11px,env(safe-area-inset-top,11px));left:11px;z-index:200;background:var(--surface);border:1px solid var(--border);border-radius:8px;width:38px;height:38px;cursor:pointer;align-items:center;justify-content:center;flex-direction:column;gap:5px;padding:0;}
 .ham-btn span{display:block;width:18px;height:2px;background:var(--text);border-radius:2px;transition:all .2s;}
+.mob-search{display:none;}
+@media(max-width:768px){.mob-search{display:flex;position:fixed;top:max(11px,env(safe-area-inset-top,11px));right:11px;z-index:200;background:var(--surface);border:1px solid var(--border);border-radius:8px;width:38px;height:38px;align-items:center;justify-content:center;cursor:pointer;font-size:16px;-webkit-tap-highlight-color:transparent;}}
 .s-ov{display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:195;}
 .bnav{display:none;}
 @media(max-width:768px){
@@ -606,6 +608,10 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 .tc.kb-sel{outline:none;border-color:var(--accent);box-shadow:0 0 0 1px var(--accent),0 0 0 4px var(--accent-soft);}
 .tc.kb-sel::after{content:'';position:absolute;left:0;top:6px;bottom:6px;width:3px;border-radius:3px;background:var(--brand-gradient);}
 .tc{position:relative;}
+/* swipe action hint (mobile) */
+.tc[data-swipe]::before{position:absolute;top:0;bottom:0;display:flex;align-items:center;font-size:12.5px;font-weight:700;pointer-events:none;z-index:1;}
+.tc[data-swipe="done"]::before{content:"✓ Done";right:16px;color:var(--q2);}
+.tc[data-swipe="snooze"]::before{content:"😴 Snooze";left:16px;color:var(--accent);}
 /* Superhuman-style hover action bar on task rows */
 .tc-actions{position:absolute;right:8px;top:3px;bottom:3px;display:flex;gap:1px;align-items:center;opacity:0;transition:opacity .12s ease;background:var(--surface2);padding:0 4px 0 18px;border-radius:9px;}
 .tc:hover .tc-actions,.tc.kb-sel .tc-actions{opacity:1;}
@@ -646,6 +652,7 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 <body>
 
 <button class="ham-btn" onclick="toggleSB()" aria-label="Menu"><span></span><span></span><span></span></button>
+<button class="mob-search" onclick="openCmdK()" aria-label="Search and commands">🔍</button>
 <div id="mobile-brand"><svg class="logo-mark" viewBox="0 0 32 32"><defs><linearGradient id="lgm2" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#58a6ff"/><stop offset="1" stop-color="#bc8cff"/></linearGradient></defs><circle cx="16" cy="16" r="12" stroke="url(#lgm2)" stroke-width="3" fill="none"/><path d="M10 16.5 L14.5 21 L22 12" stroke="url(#lgm2)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span class="logo-word">Task<span class="g">OS</span></span></div>
 <span id="offline-pill" class="hidden" style="position:fixed;top:10px;right:14px;z-index:9999;background:#ef4444;color:#fff;font-size:11px;font-weight:700;padding:4px 10px;border-radius:20px;display:none;">📡 Offline</span>
 <div class="s-ov" id="s-ov" onclick="toggleSB()"></div>
@@ -8294,17 +8301,17 @@ function _initSwipe(el,id){
     const dx=e.touches[0].clientX-startX;
     const dy=Math.abs(e.touches[0].clientY-startY);
     if(dy>30)return;
-    if(Math.abs(dx)>10){moved=true;el.style.transform=`translateX(${Math.min(60,Math.max(-60,dx))}px)`;el.style.background=dx<-20?'rgba(34,197,94,.15)':dx>20?'rgba(251,191,36,.15)':'';}
+    if(Math.abs(dx)>10){moved=true;el.style.transform=`translateX(${Math.min(72,Math.max(-72,dx))}px)`;el.style.background=dx<-20?'rgba(126,224,160,.20)':dx>20?'rgba(139,124,255,.18)':'';el.setAttribute('data-swipe',dx<-40?'done':dx>40?'snooze':'');}
   },{passive:true});
   el.addEventListener('touchend',e=>{
     const dx=e.changedTouches[0].clientX-startX;
     // spring-back: ease the card home instead of snapping
     el.style.transition='transform .22s cubic-bezier(.34,1.3,.64,1),background .2s ease';
-    el.style.transform='';el.style.background='';
+    el.style.transform='';el.style.background='';el.removeAttribute('data-swipe');
     setTimeout(()=>{el.style.transition='';},240);
     if(!moved)return;
     if(dx<-60){_haptic(15);toggleDone(id);toast('✓ Done!');}
-    else if(dx>60){_haptic(15);_showRescheduleSheet(id);}
+    else if(dx>60){_haptic(15);openSnooze(id);}
   });
 }
 function _attachSwipes(){
@@ -8472,13 +8479,30 @@ function openTaskDrawer(id){
     el=document.createElement('div');el.id='task-drawer';el.className='task-drawer';
     el.innerHTML='<div class="td-scrim" onclick="closeTaskDrawer()"></div><div class="td-panel"></div>';
     document.body.appendChild(el);
+    _initDrawerSwipe(el);
   }
   el.querySelector('.td-panel').innerHTML=`<button class="td-close" onclick="closeTaskDrawer()" aria-label="Close">×</button>`+_taskDetailHTML(t);
   el.dataset.taskId=id;
   requestAnimationFrame(()=>el.classList.add('open'));
   document.body.classList.add('modal-open');
 }
-function closeTaskDrawer(){const el=document.getElementById('task-drawer');if(el){el.classList.remove('open');delete el.dataset.taskId;}document.body.classList.remove('modal-open');}
+function closeTaskDrawer(){const el=document.getElementById('task-drawer');if(el){el.classList.remove('open');delete el.dataset.taskId;const p=el.querySelector('.td-panel');if(p){p.style.transition='';p.style.transform='';}const s=el.querySelector('.td-scrim');if(s)s.style.opacity='';}document.body.classList.remove('modal-open');}
+// Swipe the drawer right (or don't-scroll drag) to dismiss on touch devices
+function _initDrawerSwipe(el){
+  const panel=el.querySelector('.td-panel'); let sx=0,sy=0,drag=false;
+  panel.addEventListener('touchstart',e=>{sx=e.touches[0].clientX;sy=e.touches[0].clientY;drag=false;panel.style.transition='none';},{passive:true});
+  panel.addEventListener('touchmove',e=>{
+    const dx=e.touches[0].clientX-sx,dy=e.touches[0].clientY-sy;
+    if(!drag){if(Math.abs(dx)>14&&Math.abs(dx)>Math.abs(dy))drag=true;else return;}
+    if(dx>0){panel.style.transform='translateX('+dx+'px)';const s=el.querySelector('.td-scrim');if(s)s.style.opacity=String(Math.max(0,1-dx/380));}
+  },{passive:true});
+  panel.addEventListener('touchend',e=>{
+    const dx=e.changedTouches[0].clientX-sx;
+    panel.style.transition='';
+    const s=el.querySelector('.td-scrim');if(s)s.style.opacity='';
+    if(drag&&dx>100){closeTaskDrawer();}else{panel.style.transform='';}
+  });
+}
 function _taskDetailRefresh(id){
   const dr=document.getElementById('task-drawer');
   if(dr&&dr.classList.contains('open')){const t=S.tasks.find(x=>x.id===id);if(t)dr.querySelector('.td-panel').innerHTML=`<button class="td-close" onclick="closeTaskDrawer()" aria-label="Close">×</button>`+_taskDetailHTML(t);else closeTaskDrawer();}
@@ -9181,13 +9205,11 @@ if('serviceWorker' in navigator){
     if(_swRefreshing)return;_swRefreshing=true;showUpdateBanner();
   });
 }
-initQuickCapture();
-initPWA();
-initReminders();
-initChecklists();
-_initPullRefresh();
-_initSheetDismiss();
-_maybeOnboard();
+// NOTE: startup init calls were moved to the very end of the script so they
+// run AFTER every top-level const is declared. Calling initReminders() here
+// referenced DEFAULT_REMINDERS before its declaration, throwing a TDZ error
+// that silently halted all remaining top-level init (checklists, reminders,
+// pull-to-refresh, sheet-dismiss, onboarding).
 // Evening streak saver
 setInterval(()=>{
   const hr=new Date().getHours();
@@ -9722,17 +9744,9 @@ function renderChecklistBody(type){
     </div>`;
 }
 function initChecklists(){
+  // Just keep the badge in sync. The daily checklist no longer auto-pops a
+  // modal on load (too intrusive) — open it from the 📋 header button instead.
   updateChecklistBadge();
-  // Auto-show daily checklist on first open of the day if < half done
-  const today=new Date().toISOString().slice(0,10);
-  const shownKey='taskos_cb_shown_'+today;
-  if(!localStorage.getItem(shownKey)){
-    localStorage.setItem(shownKey,'1');
-    const checked=_cbChecked('daily');
-    if(checked.size<Math.ceil(CHECKLISTS.daily.length/2)){
-      setTimeout(()=>openChecklist('daily'),1500);
-    }
-  }
 }
 
 // ════════════════════════════════════════════════════════════════
@@ -12247,6 +12261,14 @@ function _goalMomentum(goalId){
   return'red';
 }
 
+// ── STARTUP (runs last, after every top-level const is initialized) ──
+initQuickCapture();
+initPWA();
+initReminders();
+initChecklists();
+_initPullRefresh();
+_initSheetDismiss();
+_maybeOnboard();
 </script>
 
 <!-- DECISION MODAL -->


### PR DESCRIPTION
More Superhuman/Notion on mobile — and while adding it, I found and fixed a real pre-existing bug.

## Root-cause fix (the important one)
The startup sequence called `initReminders()` / `initChecklists()` **before** their consts (`DEFAULT_REMINDERS`, `CHECKLISTS`) were declared, throwing a temporal-dead-zone error that **silently halted the rest of top-level init**. Consequences on production:
- **Completing a task threw** (`updateChecklistBadge` → `CHECKLISTS`) — a real user-facing crash on complete/swipe-done.
- Reminders, checklists, pull-to-refresh, sheet-dismiss, and onboarding were **dead code** (never initialized).
- The `DEFAULT_REMINDERS` console error that's shadowed the whole session.

Fix: moved the boot calls to the end of the script so every declaration exists first. **Console is now clean on load** (verified desktop + mobile, 12 views, zero errors). Also disabled the newly-re-enabled daily-checklist auto-popup (too intrusive — open it from the header button instead).

## Mobile features
- **Search / ⌘K button** (fixed top-right) so the command palette is reachable without a keyboard.
- **Row swipe polish:** a "Done" / "Snooze" hint reveals as you swipe; **swipe-right now opens the snooze picker** (was the reschedule sheet); stronger tint.
- **Task drawer swipe-to-dismiss:** swipe it right to close (scrim fades with the drag); also closes on navigation.

## Verification
Headless Chromium at 390×844 and 1280: search button opens ⌘K; swipe-left completes; swipe-right opens snooze; drawer swipe-closes; **no auto-modal on load; zero console errors** on load, on task-complete, and across 12 views; no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_