### PR TITLE
Personal OS: mobile-native pass, power features, and hosted signup

### DIFF
--- a/api/claude.js
+++ b/api/claude.js
@@ -1,0 +1,49 @@
+// Serverless Claude proxy for Task OS (Vercel).
+// Lets signed-in users run the AI features without their own API key.
+//
+// Setup:
+//   1. In Vercel → Project → Settings → Environment Variables, add:
+//        ANTHROPIC_API_KEY = sk-ant-...              (required)
+//        SUPABASE_URL      = https://xxxx.supabase.co (optional, gates to signed-in users)
+//        SUPABASE_ANON_KEY = eyJhbGci...              (optional, needed if SUPABASE_URL is set)
+//   2. Deploy. The endpoint is https://<your-app>.vercel.app/api/claude
+//   3. Paste that URL into APP_CONFIG.aiProxy in index.html.
+//
+// Note: this is a minimal proxy. For production add per-user rate limiting
+// (e.g. Upstash) so a single account can't run up your Anthropic bill.
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') { res.status(405).json({ error: 'POST only' }); return; }
+
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (!key) { res.status(500).json({ error: 'Server is missing ANTHROPIC_API_KEY' }); return; }
+
+  // Optional: require a valid Supabase session so only your users can call the proxy.
+  if (process.env.SUPABASE_URL) {
+    const tok = (req.headers.authorization || '').replace(/^Bearer\s+/i, '');
+    if (!tok) { res.status(401).json({ error: 'Sign in required' }); return; }
+    try {
+      const u = await fetch(process.env.SUPABASE_URL.replace(/\/+$/, '') + '/auth/v1/user', {
+        headers: { apikey: process.env.SUPABASE_ANON_KEY || '', Authorization: 'Bearer ' + tok },
+      });
+      if (!u.ok) { res.status(401).json({ error: 'Invalid session' }); return; }
+    } catch (e) { res.status(401).json({ error: 'Auth check failed' }); return; }
+  }
+
+  const body = (req.body && typeof req.body === 'object') ? req.body : {};
+  const prompt = String(body.prompt || '').slice(0, 20000);
+  const max_tokens = Math.min(parseInt(body.max_tokens) || 1000, 2000);
+  if (!prompt) { res.status(400).json({ error: 'Missing prompt' }); return; }
+
+  try {
+    const r = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-api-key': key, 'anthropic-version': '2023-06-01' },
+      body: JSON.stringify({ model: 'claude-haiku-4-5-20251001', max_tokens, messages: [{ role: 'user', content: prompt }] }),
+    });
+    const data = await r.json();
+    res.status(r.status).json(data);
+  } catch (e) {
+    res.status(502).json({ error: String((e && e.message) || e) });
+  }
+}

--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@ kbd{background:var(--surface2);border:1px solid var(--border);border-bottom-widt
   .eg{display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto;height:auto;gap:8px;}
   .eg>div:nth-child(1),.eg>div:nth-child(2),.eg>div:nth-child(3),.eg>div:nth-child(4),.eg>div:nth-child(7){display:none;}
   .g2,.g3,.g4,.fr{grid-template-columns:1fr;}
-  .fab{bottom:calc(74px + env(safe-area-inset-bottom,0px));}
+  .fab{display:none;} /* replaced on mobile by the bottom-nav center + button */
   .mo{align-items:flex-end;}
   .md{width:100%;max-width:100%;border-radius:16px 16px 0 0;margin:0;max-height:90vh;padding-top:8px;}
   .md::before{content:'';display:block;width:36px;height:4px;background:var(--border);border-radius:2px;margin:0 auto 12px;flex-shrink:0;}
@@ -347,7 +347,7 @@ kbd{background:var(--surface2);border:1px solid var(--border);border-bottom-widt
   /* Prevent iOS auto-zoom on input focus (requires font-size >= 16px) */
   input,textarea,select,.fc,.capi,.sb,.cmdk-i,.task-reply-input,.snooze-opt{font-size:16px!important;}
   /* Life OS 2-column grid on mobile */
-  .los-grid{grid-template-columns:1fr 1fr;}
+  .los-grid{grid-template-columns:minmax(0,1fr) minmax(0,1fr);}
   /* Dashboard header: horizontal scroll instead of wrapping */
   .ph .row{flex-wrap:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;padding-bottom:4px;gap:5px;}
   .ph .row::-webkit-scrollbar{display:none;}
@@ -382,8 +382,8 @@ body.modal-open{overflow:hidden;}
 @media(min-width:1600px){.goal-dash{grid-template-columns:repeat(5,1fr);}}
 
 /* ── LIFE OS ─────────────────────────────────────────────────── */
-.los-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-bottom:20px;}
-.los-card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:16px;}
+.los-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px;margin-bottom:20px;}
+.los-card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:16px;min-width:0;}
 .los-card h3{font-size:13px;font-weight:600;margin-bottom:10px;display:flex;align-items:center;gap:6px;}
 .los-stat{text-align:center;padding:10px;}
 .los-stat-n{font-size:28px;font-weight:700;}
@@ -644,7 +644,15 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 .task-drawer.open .td-panel{transform:none;}
 .td-close{position:absolute;top:12px;right:14px;background:none;border:none;color:var(--muted);font-size:22px;cursor:pointer;line-height:1;padding:4px 9px;border-radius:7px;transition:background .12s,color .12s;}
 .td-close:hover{color:var(--text);background:var(--hover);}
-@media(max-width:768px){.task-drawer .td-panel{width:100%;max-width:100%;border-left:none;padding-top:max(52px,calc(env(safe-area-inset-top,0px) + 46px));padding-bottom:max(24px,calc(env(safe-area-inset-bottom,0px) + 16px));}.td-close{top:max(12px,env(safe-area-inset-top,12px));width:38px;height:38px;display:flex;align-items:center;justify-content:center;padding:0;background:var(--surface2);border:1px solid var(--border);font-size:20px;}}
+@media(max-width:768px){
+  .task-drawer .td-panel{top:auto;left:0;right:0;bottom:0;width:100%;max-width:100%;height:90vh;max-height:90vh;border-left:none;border-top:1px solid var(--border);border-radius:22px 22px 0 0;box-shadow:0 -14px 44px -14px rgba(0,0,0,.6);transform:translateY(100%);transition:transform .3s cubic-bezier(.32,.72,0,1);padding:30px 18px calc(env(safe-area-inset-bottom,0px) + 20px);}
+  .task-drawer.open .td-panel{transform:none;}
+  .td-grab{display:block;position:absolute;top:9px;left:50%;transform:translateX(-50%);width:44px;height:5px;border-radius:3px;background:var(--muted);opacity:.4;}
+  .td-nav{display:none;} /* mobile navigates via swipe-through + j/k, no on-screen arrows needed */
+  .td-close{top:22px;right:16px;width:34px;height:34px;display:flex;align-items:center;justify-content:center;padding:0;background:var(--surface2);border:1px solid var(--border);font-size:19px;border-radius:9px;}
+  .task-drawer .td-panel{padding-top:62px;} /* clear the grabber + close row so the status label doesn't collide */
+}
+@media(min-width:769px){.td-nav{display:flex;gap:7px;position:absolute;top:12px;left:14px;}}
 /* Reply-to-act box */
 .task-reply{display:flex;gap:7px;margin-top:16px;padding-top:14px;border-top:1px solid var(--border);}
 .task-reply-input{flex:1;min-width:0;background:var(--surface2);border:1px solid var(--border);border-radius:10px;padding:9px 12px;color:var(--text);font:inherit;font-size:13px;outline:none;transition:border-color .12s,box-shadow .12s;}
@@ -652,6 +660,83 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 .task-reply-input:disabled{opacity:.6;}
 .task-reply-send{background:var(--accent);color:#fff;border:none;border-radius:10px;padding:0 15px;font:inherit;font-size:13px;font-weight:600;cursor:pointer;flex:none;transition:filter .12s;}
 .task-reply-send:hover{filter:brightness(1.07);}
+/* Drawer grabber + prev/next nav */
+.td-grab{display:none;}
+.td-nav{display:none;}
+.td-navbtn{background:var(--surface2);border:1px solid var(--border);color:var(--muted);width:30px;height:30px;border-radius:8px;font-size:18px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .12s,color .12s;-webkit-tap-highlight-color:transparent;}
+.td-navbtn:hover{background:var(--hover);color:var(--text);}
+/* Follow-up nudge chip row inside drawer */
+.td-nudge{display:flex;gap:6px;flex-wrap:wrap;margin-top:12px;}
+.td-nudge button{background:var(--surface2);border:1px solid var(--border);color:var(--muted);font:inherit;font-size:11.5px;font-weight:600;padding:5px 11px;border-radius:20px;cursor:pointer;transition:all .12s;-webkit-tap-highlight-color:transparent;}
+.td-nudge button:hover{border-color:var(--accent);color:var(--accent);}
+/* ── UNREAD (Superhuman inbox texture) ──────────────────────────── */
+.tc.unread .tt{font-weight:700;color:var(--text);}
+.tc-unread-dot{width:7px;height:7px;border-radius:50%;background:var(--accent);flex:none;box-shadow:0 0 7px var(--accent-soft);}
+/* checkbox pop when it flips (one-shot, added on click so it never replays on re-render) */
+@keyframes ckPop{0%{transform:scale(1);}40%{transform:scale(1.32);}100%{transform:scale(1);}}
+.ck.ckpop{animation:ckPop .28s cubic-bezier(.34,1.56,.64,1);}
+@keyframes tcSlideOut{to{opacity:0;transform:translateX(40px);height:0;margin:0;padding-top:0;padding-bottom:0;}}
+.tc.slide-out{animation:tcSlideOut .26s ease forwards;overflow:hidden;pointer-events:none;}
+/* ── SEGMENTED CONTROL (List / Board / Calendar) ────────────────── */
+.seg{display:inline-flex;background:var(--surface2);border:1px solid var(--border);border-radius:10px;padding:3px;gap:2px;margin:0 0 4px;}
+.seg-btn{background:none;border:none;color:var(--muted);font:inherit;font-size:12.5px;font-weight:600;padding:6px 15px;border-radius:7px;cursor:pointer;transition:all .14s;-webkit-tap-highlight-color:transparent;}
+.seg-btn.active{background:var(--surface);color:var(--text);box-shadow:0 1px 3px rgba(0,0,0,.12);}
+body.light .seg-btn.active{background:#fff;}
+.all-two-pane.single{grid-template-columns:1fr;}
+.all-two-pane.single .reading-pane{display:none;}
+/* ── BOARD VIEW ─────────────────────────────────────────────────── */
+.board{display:flex;gap:12px;overflow-x:auto;padding:4px 2px 12px;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;}
+.board-col{flex:0 0 300px;max-width:300px;scroll-snap-align:start;background:var(--surface2);border:1px solid var(--border);border-radius:14px;padding:12px 11px;min-width:0;}
+.board-head{display:flex;align-items:center;gap:8px;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.4px;color:var(--muted);margin-bottom:10px;padding:0 2px;}
+.board-dot{width:8px;height:8px;border-radius:50%;flex:none;}
+.board-dot[data-a="health"]{background:#7ee0a0;}
+.board-dot[data-a="wealth"]{background:#ffc078;}
+.board-dot[data-a="wisdom"]{background:#8b7cff;}
+.board-dot[data-a="relationships"]{background:#ff8fab;}
+.board-dot[data-a="experience"]{background:#63c7ff;}
+.board-dot[data-a="other"]{background:var(--muted);}
+.board-ct{margin-left:auto;background:var(--surface);border:1px solid var(--border);border-radius:20px;padding:1px 8px;font-size:11px;}
+.board-body .tc{background:var(--surface);}
+.board-empty{color:var(--muted);font-size:12px;text-align:center;padding:18px 0;opacity:.6;}
+@media(max-width:768px){.board-col{flex:0 0 84vw;max-width:84vw;}}
+/* ── CALENDAR VIEW ──────────────────────────────────────────────── */
+.cal-wrap{max-width:640px;}
+.cal-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;}
+.cal-title{font-size:15px;font-weight:700;}
+.cal-nav{display:flex;gap:6px;}
+.cal-nav button{background:var(--surface2);border:1px solid var(--border);color:var(--text);width:34px;height:34px;border-radius:9px;cursor:pointer;font-size:16px;-webkit-tap-highlight-color:transparent;}
+.cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:6px;}
+.cal-dow{text-align:center;font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.3px;color:var(--muted);padding-bottom:2px;}
+.cal-cell{aspect-ratio:1;background:var(--surface2);border:1px solid var(--border);border-radius:10px;padding:5px 6px;cursor:pointer;display:flex;flex-direction:column;gap:3px;transition:border-color .12s,background .12s;min-width:0;-webkit-tap-highlight-color:transparent;}
+.cal-cell.empty{background:transparent;border-color:transparent;cursor:default;}
+.cal-cell:not(.empty):hover{border-color:var(--accent);}
+.cal-cell.today{border-color:var(--accent);}
+.cal-cell.sel{background:var(--accent-soft);border-color:var(--accent);}
+.cal-cell.over .cal-num{color:#ff8a8a;}
+.cal-num{font-size:12.5px;font-weight:600;}
+.cal-dots{display:flex;flex-wrap:wrap;gap:2px;margin-top:auto;}
+.cal-dots i{width:5px;height:5px;border-radius:50%;background:var(--accent);display:block;}
+.cal-more{font-size:9px;color:var(--muted);font-weight:700;}
+.cal-daylist{margin-top:16px;}
+.cal-daylist h4{font-size:12px;text-transform:uppercase;letter-spacing:.4px;color:var(--muted);margin-bottom:8px;}
+/* ── BOTTOM-NAV CENTER + ADD ────────────────────────────────────── */
+.bni-add{flex:0 0 auto;padding:0;}
+.bni-add-plus{display:flex;align-items:center;justify-content:center;width:52px;height:52px;margin-top:-20px;border-radius:50%;background:var(--brand-gradient);color:#fff;font-size:30px;font-weight:300;line-height:1;box-shadow:0 7px 20px -5px var(--accent);border:3px solid var(--bg);transition:transform .18s cubic-bezier(.34,1.56,.64,1);}
+.bni-add:active .bni-add-plus{transform:scale(.88);}
+.bni-add.active::before{display:none;}
+.bni-unread{position:absolute;top:5px;right:calc(50% - 22px);background:var(--accent);color:#fff;font-size:9px;font-weight:700;min-width:15px;height:15px;padding:0 3px;border-radius:8px;display:flex;align-items:center;justify-content:center;line-height:1;}
+/* ── SLASH MENU (Quick Add) ─────────────────────────────────────── */
+.slash-menu{position:absolute;z-index:50;background:var(--surface);border:1px solid var(--border);border-radius:12px;box-shadow:0 14px 40px -12px rgba(0,0,0,.5);padding:5px;min-width:220px;max-height:260px;overflow-y:auto;}
+.slash-item{display:flex;align-items:center;gap:10px;padding:8px 11px;border-radius:8px;cursor:pointer;font-size:13px;}
+.slash-item .si-k{font-weight:700;color:var(--accent);}
+.slash-item .si-d{color:var(--muted);font-size:11.5px;margin-left:auto;}
+.slash-item.sel,.slash-item:hover{background:var(--hover);}
+/* ── SAVED VIEWS (sidebar) ──────────────────────────────────────── */
+.sv-row{display:flex;align-items:center;gap:8px;padding:5px 10px;margin:1px 8px;border-radius:6px;cursor:pointer;font-size:13px;color:var(--muted);transition:background .12s,color .12s;}
+.sv-row:hover{background:var(--hover);color:var(--text);}
+.sv-row .sv-x{margin-left:auto;opacity:0;font-size:14px;color:var(--muted);}
+.sv-row:hover .sv-x{opacity:.7;}
+.sv-star{flex:none;color:var(--accent);font-size:11px;}
 /* ── OURA RING ───────────────────────────────────────────────────── */
 .oura-ring{position:relative;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;}
 .oura-ring svg{position:absolute;top:0;left:0;transform:rotate(-90deg);}
@@ -687,6 +772,10 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
   <div class="cmdk-chip" onclick="openCmdK()" title="Command palette — search, navigate, capture">
     <span style="font-size:13px;">🔍</span><span>Quick find…</span>
     <span class="ck-keys"><kbd>⌘</kbd><kbd>K</kbd></span>
+  </div>
+  <div id="saved-views-group" class="ns-group" data-ns="views" style="display:none;">
+  <span class="ns" onclick="_toggleNsGroup(this)">Views<span class="ns-arrow">▾</span></span>
+  <div id="saved-views"></div>
   </div>
   <div class="ns-group" data-ns="main">
   <span class="ns" onclick="_toggleNsGroup(this)">Main<span class="ns-arrow">▾</span></span>
@@ -977,6 +1066,7 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
     <div><h1>✅ All Tasks</h1><p class="sub" id="atc"></p></div>
     <div class="row">
       <input class="sb" id="srch" placeholder="🔍 Search..." oninput="_debouncedSearch()">
+      <button class="btn bg sm" onclick="aiAutoTriage()">✨ Triage Inbox</button>
       <button class="btn bg sm" onclick="_aiBtn(this,aiTaskHealthCheck)">🤖 Task Health</button>
       <button class="btn bp" onclick="openAdd()">+ Add Task</button>
     </div>
@@ -989,6 +1079,14 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
     <button class="fp" onclick="setF('wisdom',this)">Wisdom</button>
     <button class="fp" onclick="setF('relationships',this)">Relationships</button>
     <button class="fp" onclick="setF('experience',this)">Experience</button>
+  </div>
+  <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;margin-bottom:6px;">
+    <div class="seg" id="all-seg">
+      <button class="seg-btn active" data-mode="list" onclick="setAllMode('list')">List</button>
+      <button class="seg-btn" data-mode="board" onclick="setAllMode('board')">Board</button>
+      <button class="seg-btn" data-mode="calendar" onclick="setAllMode('calendar')">Calendar</button>
+    </div>
+    <button class="btn bg sm" onclick="_saveCurrentView()" title="Pin this filter to the sidebar">☆ Save view</button>
   </div>
   <div class="all-two-pane">
     <div id="all-list"></div>
@@ -1478,11 +1576,11 @@ Read 50 books this year"></textarea>
 <button class="fab" aria-label="Quick actions" onclick="toggleFabDial()">+</button>
 
 <nav class="bnav" role="navigation" aria-label="Main navigation">
-  <button class="bni active" data-v="dashboard" aria-label="Home" onclick="nav('dashboard')"><span class="bni-ic">🏠</span>Home</button>
-  <button class="bni" data-v="all" aria-label="Tasks" onclick="nav('all')"><span class="bni-ic">📥</span>Tasks</button>
-  <button class="bni" data-v="buckets" aria-label="Buckets" onclick="nav('buckets')"><span class="bni-ic">📦</span>Buckets</button>
+  <button class="bni active" data-v="dashboard" aria-label="Today" onclick="nav('dashboard')"><span class="bni-ic">🏠</span>Today</button>
+  <button class="bni" data-v="all" aria-label="Inbox" onclick="nav('all')"><span class="bni-ic">📥</span>Inbox</button>
+  <button class="bni bni-add" aria-label="Add" onclick="_haptic(10);openFAB()"><span class="bni-add-plus">+</span></button>
   <button class="bni" data-v="goals" aria-label="Goals" onclick="nav('goals')"><span class="bni-ic">🏆</span>Goals</button>
-  <button class="bni" aria-label="More views" onclick="_showMoreNav()"><span class="bni-ic">☰</span>More</button>
+  <button class="bni" aria-label="Search" onclick="openCmdK()"><span class="bni-ic">🔍</span>Search</button>
 </nav>
 
 <!-- CMD+K -->
@@ -2855,7 +2953,7 @@ function doCapture(){
   const inp=document.getElementById('capi'),cat=document.getElementById('capcat');
   const raw=inp.value.trim();if(!raw)return;
   const {title,dueDate}=_parseNLDate(raw);
-  S.tasks.push({id:uid(),title,notes:'',bucket:'inbox',category:cat.value||'other',urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:dueDate||'',goalId:null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',createdAt:new Date().toISOString(),completedAt:null});
+  S.tasks.push({id:uid(),title,notes:'',bucket:'inbox',category:cat.value||'other',urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:dueDate||'',goalId:null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',read:false,createdAt:new Date().toISOString(),completedAt:null});
   save();inp.value='';cat.value='other';inp.focus();
   if(dueDate)toast('📅 Due '+fd(dueDate));
   renderCapture();updIBadge();
@@ -2963,15 +3061,66 @@ function renderEisenhower(){
 // ── ALL TASKS ─────────────────────────────────────────────────
 function setF(cat,el){fCat=cat;sessionStorage.setItem('taskos_fcat',fCat);document.querySelectorAll('.fp').forEach(p=>p.classList.remove('active'));el.classList.add('active');renderAll();}
 
-function renderAll(){
-  if(!fCat||fCat==='all'){const saved=sessionStorage.getItem('taskos_fcat');if(saved&&saved!=='all'){fCat=saved;document.querySelectorAll('.fp').forEach(p=>{p.classList.toggle('active',p.getAttribute('onclick')?.includes("'"+fCat+"'"));});}}
+let _allMode=localStorage.getItem('taskos_allmode')||'list';
+function setAllMode(m){
+  _allMode=m;localStorage.setItem('taskos_allmode',m);
+  document.querySelectorAll('#all-seg .seg-btn').forEach(b=>b.classList.toggle('active',b.dataset.mode===m));
+  const pane=document.querySelector('.all-two-pane');if(pane)pane.classList.toggle('single',m!=='list');
+  _haptic(6);renderAll();
+}
+// ── SAVED VIEWS (pin a filter to the sidebar) ──
+function _saveCurrentView(){
+  const area=(fCat&&fCat!=='all')?(LIFE_AREAS[fCat]?.label||fCat):'';
+  const q=document.getElementById('srch')?.value?.trim()||'';
+  const suggested=[area,q&&('“'+q+'”'),_allMode!=='list'?_allMode:''].filter(Boolean).join(' · ')||'All tasks';
+  showPrompt('Name this view',name=>{
+    if(!name)return;
+    S.savedViews=S.savedViews||[];
+    S.savedViews.push({id:uid(),name:name.trim(),fCat:fCat||'all',q,mode:_allMode});
+    save();_renderSavedViews();toast('☆ View saved to sidebar');
+  },{value:suggested,okLabel:'Save'});
+}
+function _openSavedView(id){
+  const v=(S.savedViews||[]).find(x=>x.id===id);if(!v)return;
+  nav('all');
+  setTimeout(()=>{
+    fCat=v.fCat||'all';sessionStorage.setItem('taskos_fcat',fCat);
+    document.querySelectorAll('.fp').forEach(p=>p.classList.toggle('active',p.getAttribute('onclick')?.includes("'"+fCat+"'")));
+    const s=document.getElementById('srch');if(s)s.value=v.q||'';
+    _allMode=v.mode||'list';localStorage.setItem('taskos_allmode',_allMode);
+    renderAll();
+  },60);
+}
+function _deleteSavedView(id,ev){
+  if(ev){ev.stopPropagation();}
+  S.savedViews=(S.savedViews||[]).filter(x=>x.id!==id);save();_renderSavedViews();
+}
+function _renderSavedViews(){
+  const wrap=document.getElementById('saved-views');const group=document.getElementById('saved-views-group');
+  if(!wrap||!group)return;
+  const vs=S.savedViews||[];
+  group.style.display=vs.length?'':'none';
+  wrap.innerHTML=vs.map(v=>`<div class="sv-row" onclick="_openSavedView('${v.id}')" title="${esc(v.name)}"><span class="sv-star">★</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${esc(v.name)}</span><span class="sv-x" onclick="_deleteSavedView('${v.id}',event)" title="Remove">×</span></div>`).join('');
+}
+function _allFilteredTasks(){
   const q=document.getElementById('srch')?.value?.toLowerCase()||'';
   let tasks=[...S.tasks];
   if(fCat!=='all')tasks=tasks.filter(t=>LIFE_AREAS[fCat]?_catArea(t.category)===fCat:t.category===fCat);
   if(q)tasks=tasks.filter(t=>t.title.toLowerCase().includes(q)||(t.notes||'').toLowerCase().includes(q));
+  return tasks;
+}
+function renderAll(){
+  if(!fCat||fCat==='all'){const saved=sessionStorage.getItem('taskos_fcat');if(saved&&saved!=='all'){fCat=saved;document.querySelectorAll('.fp').forEach(p=>{p.classList.toggle('active',p.getAttribute('onclick')?.includes("'"+fCat+"'"));});}}
+  document.querySelectorAll('#all-seg .seg-btn').forEach(b=>b.classList.toggle('active',b.dataset.mode===_allMode));
+  const pane=document.querySelector('.all-two-pane');if(pane)pane.classList.toggle('single',_allMode!=='list');
+  const tasks=_allFilteredTasks();
+  document.getElementById('atc').textContent=tasks.filter(t=>t.status!=='done').length+' active · '+tasks.filter(t=>t.status==='done').length+' done';
+  _updateUnreadBadges();
+  if(_allMode==='board'){renderAllBoard(tasks);return;}
+  if(_allMode==='calendar'){renderAllCalendar(tasks);return;}
+  // ── LIST ──
   const bo={inbox:0,'this-week':1,'this-month':2,backlog:3,someday:4};
   tasks.sort((a,b)=>{if(a.status==='done'&&b.status!=='done')return 1;if(a.status!=='done'&&b.status==='done')return -1;return(bo[a.bucket]||9)-(bo[b.bucket]||9);});
-  document.getElementById('atc').textContent=tasks.filter(t=>t.status!=='done').length+' active · '+tasks.filter(t=>t.status==='done').length+' done';
   if(!tasks.length){document.getElementById('all-list').innerHTML=_empty('✅','No tasks here','Add your first task or adjust the filter above.','<button class="btn bp sm" onclick="openAdd()">+ Add Task</button>');_selTaskId=null;renderReadingPane(null);return;}
   const grouped={};
   tasks.forEach(t=>{const k=t.status==='done'?'done':t.bucket;(grouped[k]=grouped[k]||[]).push(t);});
@@ -2984,13 +3133,71 @@ function renderAll(){
   });
   document.getElementById('all-list').innerHTML=html;
   setTimeout(_attachSwipes,0);
-  // Two-pane reading view: keep selection valid, default to first task, refresh pane
-  if(document.getElementById('reading-pane')){
+  // Two-pane reading view (desktop only): keep selection valid, default to first task, refresh pane.
+  // On mobile the pane is hidden, so we must NOT auto-open (which would mark the top task read).
+  if(document.getElementById('reading-pane')&&window.innerWidth>=1000){
     const ids=[...document.querySelectorAll('#all-list .tc[data-swipe-id]')].map(c=>c.dataset.swipeId);
     if(!_selTaskId||!ids.includes(_selTaskId))_selTaskId=ids[0]||null;
     _paintKbSel();
     renderReadingPane(_selTaskId);
   }
+}
+// ── BOARD VIEW (life-area columns; horizontal scroll-snap on mobile) ──
+function renderAllBoard(tasks){
+  const areas=[['health','Health'],['wealth','Wealth'],['wisdom','Wisdom'],['relationships','Relationships'],['experience','Experience']];
+  const byArea={};areas.forEach(([k])=>byArea[k]=[]);const other=[];
+  tasks.filter(t=>t.status!=='done').forEach(t=>{const a=_catArea(t.category);if(byArea[a])byArea[a].push(t);else other.push(t);});
+  let cols=areas.map(([k,l])=>({k,l,items:byArea[k]}));
+  if(other.length)cols.push({k:'other',l:'Other',items:other});
+  // If a life-area filter is active, only that column is meaningful — show it wide
+  const html=`<div class="board">${cols.map(c=>`
+    <div class="board-col">
+      <div class="board-head"><span class="board-dot" data-a="${c.k}"></span>${c.l}<span class="board-ct">${c.items.length}</span></div>
+      <div class="board-body">${c.items.length?c.items.map(t=>tcHTML(t,false,true)).join(''):'<div class="board-empty">Nothing here</div>'}</div>
+    </div>`).join('')}</div>`;
+  document.getElementById('all-list').innerHTML=html;
+  setTimeout(_attachSwipes,0);
+}
+// ── CALENDAR VIEW (month grid; tap a day to see what's due) ──
+let _calMonth=null,_calSel=null;
+function _calShift(delta){const b=_calMonth||new Date();_calMonth=new Date(b.getFullYear(),b.getMonth()+delta,1);_calSel=null;renderAll();}
+function _calPick(ds){_calSel=(_calSel===ds?null:ds);renderAll();}
+function renderAllCalendar(tasks){
+  const now=new Date();
+  const base=_calMonth||new Date(now.getFullYear(),now.getMonth(),1);
+  _calMonth=new Date(base.getFullYear(),base.getMonth(),1);
+  const y=_calMonth.getFullYear(),m=_calMonth.getMonth();
+  const todayStr=now.toISOString().slice(0,10);
+  // bucket tasks by dueDate
+  const byDay={};
+  tasks.filter(t=>t.dueDate&&t.status!=='done').forEach(t=>{(byDay[t.dueDate]=byDay[t.dueDate]||[]).push(t);});
+  const first=new Date(y,m,1),startDow=first.getDay(),daysIn=new Date(y,m+1,0).getDate();
+  const dows=['Su','Mo','Tu','We','Th','Fr','Sa'];
+  let cells='';
+  for(let i=0;i<startDow;i++)cells+='<div class="cal-cell empty"></div>';
+  for(let d=1;d<=daysIn;d++){
+    const ds=`${y}-${String(m+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+    const items=byDay[ds]||[];
+    const over=ds<todayStr&&items.length;
+    const dots=items.slice(0,3).map(()=>'<i></i>').join('')+(items.length>3?`<span class="cal-more">+${items.length-3}</span>`:'');
+    cells+=`<div class="cal-cell ${ds===todayStr?'today':''} ${_calSel===ds?'sel':''} ${over?'over':''}" onclick="_calPick('${ds}')"><div class="cal-num">${d}</div><div class="cal-dots">${dots}</div></div>`;
+  }
+  const monthLabel=_calMonth.toLocaleDateString('en-US',{month:'long',year:'numeric'});
+  let dayList='';
+  if(_calSel){
+    const items=(byDay[_calSel]||[]);
+    const dlabel=new Date(_calSel+'T12:00:00').toLocaleDateString('en-US',{weekday:'long',month:'short',day:'numeric'});
+    dayList=`<div class="cal-daylist"><h4>${dlabel} · ${items.length} due</h4>${items.length?items.map(t=>tcHTML(t)).join(''):`<div class="board-empty" style="text-align:left;">Nothing due — <a onclick="openAdd('this-week')" style="color:var(--accent);cursor:pointer;">add a task</a></div>`}</div>`;
+  } else {
+    const undated=tasks.filter(t=>!t.dueDate&&t.status!=='done').length;
+    dayList=`<div class="cal-daylist"><h4>Tap a day to see what's due</h4><div style="font-size:12px;color:var(--muted);line-height:1.6;">${undated} active task${undated===1?'':'s'} have no due date. Open one and set a date to place it on the calendar.</div></div>`;
+  }
+  document.getElementById('all-list').innerHTML=`<div class="cal-wrap">
+    <div class="cal-head"><div class="cal-title">${monthLabel}</div><div class="cal-nav"><button onclick="_calShift(-1)" aria-label="Previous month">‹</button><button onclick="_calShift(1)" aria-label="Next month">›</button></div></div>
+    <div class="cal-grid">${dows.map(d=>`<div class="cal-dow">${d}</div>`).join('')}${cells}</div>
+    ${dayList}
+  </div>`;
+  setTimeout(_attachSwipes,0);
 }
 
 // ── GOALS ─────────────────────────────────────────────────────
@@ -3192,9 +3399,10 @@ function tcHTML(t,showT3btn=false,hideGoal=false){
   const cat=CATS[t.category]||CATS.other;
   const gl=t.goalId?(S.goals||[]).find(g=>g.id===t.goalId):null;
   const blocked=t.blockedBy?.length&&t.blockedBy.some(bid=>S.tasks.find(x=>x.id===bid&&x.status!=='done'));
-  return`<div class="tc fi ${t.status==='done'?'done':''} ${t.isT3&&t.status!=='done'?'top3':''}" data-swipe-id="${t.id}" onclick="openEdit('${t.id}')">
+  const unread=t.read===false&&t.status!=='done';
+  return`<div class="tc fi ${t.status==='done'?'done':''} ${unread?'unread':''} ${t.isT3&&t.status!=='done'?'top3':''}" data-swipe-id="${t.id}" onclick="openEdit('${t.id}')">
     <div class="ck ${t.status==='done'?'on':t.status==='in-progress'?'ip':''}" onclick="event.stopPropagation();cycleStatus('${t.id}')" title="${t.status==='done'?'Done':t.status==='in-progress'?'In progress':'To do — click to start'}">${t.status==='done'?'<span style="color:#fff;font-size:10px;">✓</span>':t.status==='in-progress'?'<span style="font-size:9px;">▶</span>':''}</div>
-    <span class="tc-pri ${q==='q1'?'hi':''}" title="${EQ[q].l}"></span>
+    ${unread?'<span class="tc-unread-dot" title="Unread"></span>':`<span class="tc-pri ${q==='q1'?'hi':''}" title="${EQ[q].l}"></span>`}
     <span class="tt">${t.title}</span>
     ${t.checklist?.length?`<span class="tc-chk-ct">${t.checklist.filter(c=>c.done).length}/${t.checklist.length}</span>`:''}
     ${blocked?'<span class="tc-flag" style="color:var(--q1);" title="Blocked">Blocked</span>':''}
@@ -3256,6 +3464,7 @@ function _openAddWithTitle(bucket,title){
 
 function openEdit(id){
   const t=S.tasks.find(x=>x.id===id);if(!t)return;
+  _markRead(id);
   editT=id;
   document.getElementById('tm-title').textContent='Edit Task';
   document.getElementById('t-title').value=t.title;
@@ -3384,7 +3593,12 @@ function toggleDone(id){
 
 function cycleStatus(id){
   const t=S.tasks.find(x=>x.id===id);if(!t)return;
-  if(t.status==='todo'){t.status='in-progress';t.completedAt=null;save();refresh();updIBadge();updateChecklistBadge();}
+  if(t.status==='todo'){
+    const ck=document.querySelector('.tc[data-swipe-id="'+id+'"] .ck');
+    if(ck){ck.classList.add('ip','ckpop');}_haptic(8);
+    t.status='in-progress';t.completedAt=null;save();updIBadge();updateChecklistBadge();
+    setTimeout(refresh,190);
+  }
   else toggleDone(id);
 }
 function mvB(id,b){const t=S.tasks.find(x=>x.id===id);if(!t)return;t.bucket=b;save();refresh();}
@@ -3400,7 +3614,7 @@ function openSnooze(id){
   _snoozeId=id;
   let el=document.getElementById('snooze-modal');
   if(!el){el=document.createElement('div');el.className='mo hidden';el.id='snooze-modal';el.addEventListener('click',e=>{if(e.target===el)closeSnooze();});document.body.appendChild(el);}
-  const opts=[['Later today',_snoozeAt(0,18)],['Tonight',_snoozeAt(0,21)],['Tomorrow',_snoozeAt(1,9)],['This weekend',_nextWeekendD()],['Next week',_nextMondayD()]];
+  const opts=[['Later today',_snoozeAt(0,18)],['Tonight',_snoozeAt(0,21)],['Tomorrow',_snoozeAt(1,9)],['In 3 days',_snoozeAt(3,9)],['This weekend',_nextWeekendD()],['Next week',_nextMondayD()],['In 1 week',_snoozeAt(7,9)]];
   el.innerHTML=`<div class="md" style="width:340px;max-width:92vw;">
     <div class="mh"><h3 style="font-size:15px;">Snooze until…</h3><button class="mc" onclick="closeSnooze()">×</button></div>
     <div class="snooze-list">${opts.map(([label,d])=>`<button class="snooze-opt" onclick="snoozeTask(_snoozeId,new Date(${d.getTime()}));closeSnooze();"><span>${label}</span><span class="sh">${_fmtSnooze(d)}</span></button>`).join('')}</div>
@@ -3617,6 +3831,15 @@ document.querySelectorAll('.mo').forEach(o=>o.addEventListener('click',function(
 
 // ── INBOX BADGE ───────────────────────────────────────────────
 function updIBadge(){const c=active().filter(t=>t.bucket==='inbox').length;const b=document.getElementById('ib');b.innerHTML=c?`<span class="ibadge">${c}</span>`:'';}
+// Unread count on the bottom-nav "Inbox" tab (Superhuman inbox texture)
+function _updateUnreadBadges(){
+  const n=S.tasks.filter(t=>t.read===false&&t.status!=='done').length;
+  document.querySelectorAll('.bni[data-v="all"]').forEach(b=>{
+    let dot=b.querySelector('.bni-unread');
+    if(n){if(!dot){dot=document.createElement('span');dot.className='bni-unread';b.appendChild(dot);}dot.textContent=n>9?'9+':n;}
+    else if(dot)dot.remove();
+  });
+}
 
 // ── CMD+K ─────────────────────────────────────────────────────
 let _cmdkItems=[],_cmdkIdx=0;
@@ -3682,7 +3905,7 @@ function _cmdkCapture(input){
   const nl=_parseNLDate(input);
   const {title,goalId}=_parseGoalTag(nl.title);
   const dueDate=nl.dueDate;
-  S.tasks.push({id:uid(),title,notes:'',bucket,category:cat,urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:dueDate||'',goalId:goalId||null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',createdAt:new Date().toISOString(),completedAt:null});
+  S.tasks.push({id:uid(),title,notes:'',bucket,category:cat,urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:dueDate||'',goalId:goalId||null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',read:false,createdAt:new Date().toISOString(),completedAt:null});
   save();closeCmdK();refresh();updIBadge();
   const g=goalId?(S.goals||[]).find(x=>x.id===goalId):null;
   toast((g?'↳ '+esc(g.title)+' · ':'')+(dueDate?'Captured — due '+fd(dueDate):'Captured'));
@@ -3863,6 +4086,11 @@ document.addEventListener('click',e=>{window._lastClickX=e.clientX;window._lastC
 document.addEventListener('keydown',e=>{
   if((e.metaKey||e.ctrlKey)&&e.key==='k'){e.preventDefault();openCmdK();return;}
   if(e.target.tagName==='INPUT'||e.target.tagName==='TEXTAREA')return;
+  // When the task drawer is open, j/k browse to the next/previous task in place
+  if(document.getElementById('task-drawer')?.classList.contains('open')){
+    if(e.key==='j'||e.key==='ArrowDown'){e.preventDefault();_drawerNav(1);return;}
+    if(e.key==='k'||e.key==='ArrowUp'){e.preventDefault();_drawerNav(-1);return;}
+  }
   if(e.key==='q'||e.key==='Q'){e.preventDefault();openQuickCapture();return;}
   const _inInput=document.activeElement&&['INPUT','TEXTAREA','SELECT'].includes(document.activeElement.tagName);
   if(!_inInput){
@@ -4407,6 +4635,72 @@ function showAiOut(title, text){
   document.getElementById('ai-out-modal').classList.remove('hidden');
 }
 function daysSinceDate(d){if(!d)return 999;return Math.floor((Date.now()-new Date(d))/(86400000));}
+
+// ── AI AUTO-TRIAGE OF INBOX ───────────────────────────────────
+let _triageProposals=null;
+async function aiAutoTriage(){
+  const inbox=S.tasks.filter(t=>t.bucket==='inbox'&&t.status!=='done');
+  if(!inbox.length){toast('📥 Inbox is already clear!');return;}
+  if(!S.claudeKey){toast('Add your Claude API key in Settings to auto-triage');return;}
+  if(!_aiLock('aiAutoTriage'))return;
+  toast('✨ AI triaging your inbox…');
+  const cats=Object.keys(CATS).join(', ');
+  const list=inbox.slice(0,40).map(t=>`${t.id} :: ${t.title}`).join('\n');
+  const prompt=`You are a task triage assistant. For each inbox task below, decide the best bucket and category.
+Buckets: this-week (urgent/important, do soon), this-month (important, not urgent), backlog (someday-ish but real), someday (aspirational, no timeline).
+Categories: ${cats}.
+TASKS (format: id :: title):
+${list}
+
+Return ONLY a JSON array, no prose. Each item: {"id":"<id>","bucket":"<bucket>","category":"<category>"}.`;
+  const raw=await callClaude(prompt,1500);
+  _aiUnlock('aiAutoTriage');
+  if(!raw){return;}
+  let arr=null;
+  try{const m=raw.match(/\[[\s\S]*\]/);arr=JSON.parse(m?m[0]:raw);}catch(e){toast('AI returned an unexpected format — try again');return;}
+  if(!Array.isArray(arr)||!arr.length){toast('No triage suggestions came back');return;}
+  const validB=['this-week','this-month','backlog','someday'];
+  _triageProposals=arr.map(p=>{
+    const t=inbox.find(x=>x.id===p.id);if(!t)return null;
+    const bucket=validB.includes(p.bucket)?p.bucket:'backlog';
+    const category=CATS[p.category]?p.category:t.category;
+    return {id:t.id,title:t.title,bucket,category,apply:true};
+  }).filter(Boolean);
+  if(!_triageProposals.length){toast('No matching tasks to triage');return;}
+  _renderTriageModal();
+}
+function _renderTriageModal(){
+  let el=document.getElementById('triage-modal');
+  if(!el){el=document.createElement('div');el.className='mo hidden';el.id='triage-modal';el.addEventListener('click',e=>{if(e.target===el)closeM('triage-modal');});document.body.appendChild(el);}
+  const bl={'this-week':'🔴 This Week','this-month':'🟠 This Month','backlog':'🟢 Backlog','someday':'🔵 Someday'};
+  const rows=_triageProposals.map((p,i)=>`
+    <label style="display:flex;align-items:center;gap:10px;padding:9px 4px;border-bottom:1px solid var(--border);cursor:pointer;">
+      <input type="checkbox" ${p.apply?'checked':''} onchange="_triageProposals[${i}].apply=this.checked" style="width:17px;height:17px;flex:none;">
+      <span style="flex:1;min-width:0;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${esc(p.title)}</span>
+      <span style="font-size:11px;color:var(--muted);white-space:nowrap;">${CATS[p.category]?.l||p.category}</span>
+      <span style="font-size:11px;font-weight:600;white-space:nowrap;">${bl[p.bucket]||p.bucket}</span>
+    </label>`).join('');
+  el.innerHTML=`<div class="md" style="width:520px;max-width:94vw;max-height:80vh;display:flex;flex-direction:column;">
+    <div class="mh"><h3>✨ AI Triage — ${_triageProposals.length} task${_triageProposals.length>1?'s':''}</h3><button class="mc" onclick="closeM('triage-modal')">×</button></div>
+    <p style="font-size:12px;color:var(--muted);margin-bottom:6px;">Review the proposed buckets, uncheck any you want to skip, then apply.</p>
+    <div style="overflow-y:auto;flex:1;margin:0 -4px;">${rows}</div>
+    <div class="mf" style="margin-top:12px;">
+      <button class="btn bg" onclick="closeM('triage-modal')">Cancel</button>
+      <button class="btn bp" onclick="_applyTriage()">Apply triage</button>
+    </div>
+  </div>`;
+  el.classList.remove('hidden');document.body.classList.add('modal-open');
+}
+function _applyTriage(){
+  let n=0;
+  (_triageProposals||[]).forEach(p=>{
+    if(!p.apply)return;
+    const t=S.tasks.find(x=>x.id===p.id);if(!t)return;
+    t.bucket=p.bucket;t.category=p.category;n++;
+  });
+  save();refresh();updIBadge();closeM('triage-modal');_haptic(15);
+  toast(`✨ Triaged ${n} task${n===1?'':'s'} out of your inbox`);
+}
 
 // ── AI SEQUENCE SCORE (Eat That Frog) ─────────────────────────
 async function aiSequenceTasks(){
@@ -6102,8 +6396,73 @@ function clearOneThing(id){
 // ════════════════════════════════════════════════════════════════
 // QUICK ADD
 // ════════════════════════════════════════════════════════════════
-function openQuickAdd(){document.getElementById('qa-input').value='';document.getElementById('quick-add-modal').classList.remove('hidden');setTimeout(()=>document.getElementById('qa-input').focus(),50);}
-function doQuickAdd(){const lines=document.getElementById('qa-input').value.split('\n').map(l=>l.trim()).filter(Boolean);if(!lines.length)return;let _linked=0;lines.forEach(raw=>{const {title,goalId}=_parseGoalTag(raw);if(goalId)_linked++;S.tasks.push({id:uid(),title,notes:'',bucket:'inbox',category:'other',urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:'',goalId:goalId||null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',createdAt:new Date().toISOString(),completedAt:null});});save();refresh();closeM('quick-add-modal');toast(`Added ${lines.length} task${lines.length>1?'s':''}${_linked?' · '+_linked+' linked to a goal':''}`);}
+function openQuickAdd(){document.getElementById('qa-input').value='';document.getElementById('quick-add-modal').classList.remove('hidden');const m=document.getElementById('qa-slash');if(m)m.style.display='none';setTimeout(()=>document.getElementById('qa-input').focus(),50);}
+// ── SLASH COMMANDS (Notion-style /menu in Quick Add) ──
+const SLASH_CMDS=[
+  {k:'/today',d:'Due today',patch:{bucket:'this-week',due:0}},
+  {k:'/tomorrow',d:'Due tomorrow',patch:{bucket:'this-week',due:1}},
+  {k:'/week',d:'This week',patch:{bucket:'this-week'}},
+  {k:'/month',d:'This month',patch:{bucket:'this-month'}},
+  {k:'/someday',d:'Someday',patch:{bucket:'someday'}},
+  {k:'/health',d:'Health area',patch:{category:'health'}},
+  {k:'/wealth',d:'Wealth area',patch:{category:'givelink'}},
+  {k:'/wisdom',d:'Wisdom area',patch:{category:'learning'}},
+  {k:'/relationships',d:'Relationships',patch:{category:'relationships'}},
+  {k:'/experience',d:'Experience',patch:{category:'other'}},
+];
+let _slashIdx=0;
+function _qaCurLine(ta){const p=ta.selectionStart;const start=ta.value.lastIndexOf('\n',p-1)+1;let end=ta.value.indexOf('\n',p);if(end<0)end=ta.value.length;return{start,end,text:ta.value.slice(start,end),caret:p};}
+function _qaSlashToken(ta){const {start,caret}=_qaCurLine(ta);const before=ta.value.slice(start,caret);const mm=before.match(/(^|\s)(\/[a-z]*)$/i);return mm?mm[2]:null;}
+function _qaSlash(ta){
+  const tok=_qaSlashToken(ta);const menu=document.getElementById('qa-slash');if(!menu)return;
+  if(tok===null){menu.style.display='none';return;}
+  const q=tok.slice(1).toLowerCase();
+  const matches=SLASH_CMDS.filter(c=>c.k.slice(1).startsWith(q));
+  if(!matches.length){menu.style.display='none';return;}
+  _slashIdx=0;menu._matches=matches;
+  menu.innerHTML=matches.map((c,i)=>`<div class="slash-item ${i===0?'sel':''}" data-i="${i}" onmousedown="event.preventDefault();_qaSlashPick(${i})"><span class="si-k">${c.k}</span><span class="si-d">${c.d}</span></div>`).join('');
+  menu.style.display='block';
+}
+function _qaSlashKey(ta,e){
+  const menu=document.getElementById('qa-slash');if(!menu||menu.style.display==='none')return;
+  const items=menu._matches||[];
+  if(e.key==='ArrowDown'){e.preventDefault();_slashIdx=(_slashIdx+1)%items.length;_qaSlashPaint();}
+  else if(e.key==='ArrowUp'){e.preventDefault();_slashIdx=(_slashIdx-1+items.length)%items.length;_qaSlashPaint();}
+  else if(e.key==='Enter'||e.key==='Tab'){e.preventDefault();_qaSlashPick(_slashIdx);}
+  else if(e.key==='Escape'){menu.style.display='none';}
+}
+function _qaSlashPaint(){const menu=document.getElementById('qa-slash');[...menu.querySelectorAll('.slash-item')].forEach((el,i)=>el.classList.toggle('sel',i===_slashIdx));}
+function _qaSlashPick(i){
+  const ta=document.getElementById('qa-input');const menu=document.getElementById('qa-slash');
+  const cmd=(menu._matches||[])[i];if(!cmd){menu.style.display='none';return;}
+  const {start,caret}=_qaCurLine(ta);
+  const before=ta.value.slice(0,caret);const tokStart=before.search(/\/[a-z]*$/i);
+  const newVal=ta.value.slice(0,tokStart)+cmd.k+' '+ta.value.slice(caret);
+  ta.value=newVal;const np=tokStart+cmd.k.length+1;ta.setSelectionRange(np,np);
+  menu.style.display='none';ta.focus();
+}
+function _parseSlash(line){
+  const patch={};
+  let title=line.replace(/(^|\s)(\/[a-z]+)/gi,(m,sp,tok)=>{
+    const c=SLASH_CMDS.find(x=>x.k===tok.toLowerCase());
+    if(c){Object.assign(patch,c.patch);return sp?' ':'';}
+    return m;
+  }).replace(/\s+/g,' ').trim();
+  let dueDate='';
+  if(patch.due!==undefined){const d=new Date();d.setDate(d.getDate()+patch.due);dueDate=d.toISOString().slice(0,10);}
+  return {title,bucket:patch.bucket||'inbox',category:patch.category||'other',dueDate};
+}
+function doQuickAdd(){
+  const lines=document.getElementById('qa-input').value.split('\n').map(l=>l.trim()).filter(Boolean);if(!lines.length)return;
+  let _linked=0;
+  lines.forEach(raw=>{
+    const sl=_parseSlash(raw);
+    const {title,goalId}=_parseGoalTag(sl.title);
+    if(goalId)_linked++;
+    S.tasks.push({id:uid(),title,notes:'',bucket:sl.bucket,category:sl.category,urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:sl.dueDate,goalId:goalId||null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',read:false,createdAt:new Date().toISOString(),completedAt:null});
+  });
+  save();refresh();closeM('quick-add-modal');toast(`Added ${lines.length} task${lines.length>1?'s':''}${_linked?' · '+_linked+' linked to a goal':''}`);
+}
 
 // ════════════════════════════════════════════════════════════════
 // START DAY MODAL
@@ -8479,6 +8838,7 @@ function _taskDetailHTML(t){
 }
 function renderReadingPane(id){
   const pane=document.getElementById('reading-pane'); if(!pane)return;
+  if(id)_markRead(id);
   const t=id?S.tasks.find(x=>x.id===id):null;
   if(!t){
     pane.innerHTML=`<div style="text-align:center;color:var(--muted);padding:44px 12px;">
@@ -8489,9 +8849,15 @@ function renderReadingPane(id){
   }
   pane.innerHTML=_taskDetailHTML(t);
 }
-// Universal task-detail drawer (slides in from the right; replaces the modal outside All Tasks)
+// Universal task-detail drawer (bottom sheet on mobile, right-slide on desktop)
+let _drawerIds=[];
+function _drawerPanelHTML(t){
+  const navBtns=`<div class="td-nav"><button class="td-navbtn" onclick="_drawerNav(-1)" aria-label="Previous task">‹</button><button class="td-navbtn" onclick="_drawerNav(1)" aria-label="Next task">›</button></div>`;
+  return `<div class="td-grab" onclick="closeTaskDrawer()"></div>${navBtns}<button class="td-close" onclick="closeTaskDrawer()" aria-label="Close">×</button>`+_taskDetailHTML(t);
+}
 function openTaskDrawer(id){
   const t=S.tasks.find(x=>x.id===id); if(!t)return;
+  _markRead(id);
   let el=document.getElementById('task-drawer');
   if(!el){
     el=document.createElement('div');el.id='task-drawer';el.className='task-drawer';
@@ -8499,32 +8865,64 @@ function openTaskDrawer(id){
     document.body.appendChild(el);
     _initDrawerSwipe(el);
   }
-  el.querySelector('.td-panel').innerHTML=`<button class="td-close" onclick="closeTaskDrawer()" aria-label="Close">×</button>`+_taskDetailHTML(t);
+  // Build the browse order from the tasks visible in the active view (for j/k + swipe-through)
+  if(!_drawerIds.includes(id)){_drawerIds=[...document.querySelectorAll('.view.active .tc[data-swipe-id]')].map(c=>c.dataset.swipeId).filter((v,i,a)=>a.indexOf(v)===i);}
+  const panel=el.querySelector('.td-panel');
+  panel.innerHTML=_drawerPanelHTML(t);
+  panel.scrollTop=0;
   el.dataset.taskId=id;
   requestAnimationFrame(()=>el.classList.add('open'));
   document.body.classList.add('modal-open');
 }
+function _drawerNav(dir){
+  const el=document.getElementById('task-drawer');const cur=el?.dataset.taskId;
+  if(!cur||!_drawerIds.length)return;
+  let i=_drawerIds.indexOf(cur);if(i<0)return;
+  i+=dir;
+  if(i<0||i>=_drawerIds.length){_haptic(5);return;}
+  _haptic(8);openTaskDrawer(_drawerIds[i]);
+}
 function closeTaskDrawer(){const el=document.getElementById('task-drawer');if(el){el.classList.remove('open');delete el.dataset.taskId;const p=el.querySelector('.td-panel');if(p){p.style.transition='';p.style.transform='';}const s=el.querySelector('.td-scrim');if(s)s.style.opacity='';}document.body.classList.remove('modal-open');}
-// Swipe the drawer right (or don't-scroll drag) to dismiss on touch devices
+// Direction-aware dismiss: swipe DOWN on the mobile sheet, or LEFT/RIGHT to browse; swipe RIGHT to dismiss on desktop.
 function _initDrawerSwipe(el){
-  const panel=el.querySelector('.td-panel'); let sx=0,sy=0,drag=false;
-  panel.addEventListener('touchstart',e=>{sx=e.touches[0].clientX;sy=e.touches[0].clientY;drag=false;panel.style.transition='none';},{passive:true});
+  const panel=el.querySelector('.td-panel'); let sx=0,sy=0,drag=null,atTop=true;
+  panel.addEventListener('touchstart',e=>{sx=e.touches[0].clientX;sy=e.touches[0].clientY;drag=null;atTop=panel.scrollTop<=0;panel.style.transition='none';},{passive:true});
   panel.addEventListener('touchmove',e=>{
     const dx=e.touches[0].clientX-sx,dy=e.touches[0].clientY-sy;
-    if(!drag){if(Math.abs(dx)>14&&Math.abs(dx)>Math.abs(dy))drag=true;else return;}
-    if(dx>0){panel.style.transform='translateX('+dx+'px)';const s=el.querySelector('.td-scrim');if(s)s.style.opacity=String(Math.max(0,1-dx/380));}
+    const mobile=window.innerWidth<=768;
+    if(drag===null){if(Math.abs(dx)<12&&Math.abs(dy)<12)return;drag=Math.abs(dx)>Math.abs(dy)?'x':'y';}
+    const s=el.querySelector('.td-scrim');
+    if(mobile){
+      if(drag==='y'&&dy>0&&atTop){panel.style.transform='translateY('+dy+'px)';if(s)s.style.opacity=String(Math.max(0,1-dy/500));}
+    } else {
+      if(drag==='x'&&dx>0){panel.style.transform='translateX('+dx+'px)';if(s)s.style.opacity=String(Math.max(0,1-dx/380));}
+    }
   },{passive:true});
   panel.addEventListener('touchend',e=>{
-    const dx=e.changedTouches[0].clientX-sx;
-    panel.style.transition='';
+    const dx=e.changedTouches[0].clientX-sx,dy=e.changedTouches[0].clientY-sy;
+    const mobile=window.innerWidth<=768;
+    panel.style.transition='';panel.style.transform='';
     const s=el.querySelector('.td-scrim');if(s)s.style.opacity='';
-    if(drag&&dx>100){closeTaskDrawer();}else{panel.style.transform='';}
+    if(mobile){
+      if(drag==='y'&&dy>110&&atTop){closeTaskDrawer();}
+      else if(drag==='x'&&Math.abs(dx)>70){_drawerNav(dx<0?1:-1);}
+    } else {
+      if(drag==='x'&&dx>100){closeTaskDrawer();}
+    }
   });
 }
 function _taskDetailRefresh(id){
   const dr=document.getElementById('task-drawer');
-  if(dr&&dr.classList.contains('open')){const t=S.tasks.find(x=>x.id===id);if(t)dr.querySelector('.td-panel').innerHTML=`<button class="td-close" onclick="closeTaskDrawer()" aria-label="Close">×</button>`+_taskDetailHTML(t);else closeTaskDrawer();}
+  if(dr&&dr.classList.contains('open')){const t=S.tasks.find(x=>x.id===id);if(t){const sc=dr.querySelector('.td-panel').scrollTop;dr.querySelector('.td-panel').innerHTML=_drawerPanelHTML(t);dr.querySelector('.td-panel').scrollTop=sc;}else closeTaskDrawer();}
   if(document.getElementById('reading-pane')&&document.getElementById('v-all')?.classList.contains('active'))renderReadingPane(id);
+}
+// Mark a task read (Superhuman inbox texture) — updates the card in place without a full re-render
+function _markRead(id){
+  const t=S.tasks.find(x=>x.id===id);if(!t||t.read!==false)return;
+  t.read=true;save();
+  const card=document.querySelector('.tc[data-swipe-id="'+id+'"]');
+  if(card){card.classList.remove('unread');card.querySelector('.tc-unread-dot')?.remove();}
+  if(typeof _updateUnreadBadges==='function')_updateUnreadBadges();
 }
 // Click a task card outside All Tasks → open the drawer instead of the edit modal
 // (on mobile, All Tasks has no inline pane, so it uses the drawer too)
@@ -9322,7 +9720,7 @@ function handleQC(e){
   const timeBlock=timeTag?parseInt(timeTag[1]):null;
   const title=raw.replace(/@\w+/g,'').replace(/![\w]+/g,'').replace(/~\d+m?/g,'').trim();
   if(!title){closeQuickCapture();return;}
-  S.tasks.push({id:uid(),title,notes:'',bucket,category:cat,urgency,importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock,dueDate:'',goalId:null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',createdAt:new Date().toISOString(),completedAt:null});
+  S.tasks.push({id:uid(),title,notes:'',bucket,category:cat,urgency,importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock,dueDate:'',goalId:null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',read:false,createdAt:new Date().toISOString(),completedAt:null});
   save();updIBadge();
   inp.value='✓ Captured!';inp.style.color='var(--accent)';
   setTimeout(()=>{inp.style.color='';closeQuickCapture();},900);
@@ -12287,6 +12685,7 @@ initChecklists();
 _initPullRefresh();
 _initSheetDismiss();
 _maybeOnboard();
+try{_renderSavedViews();_updateUnreadBadges();}catch(e){}
 // Fade out the launch splash once the app has painted (with a safety fallback)
 (function(){
   function _hideSplash(){const s=document.getElementById('app-splash');if(s&&!s.classList.contains('hide')){s.classList.add('hide');setTimeout(()=>s.remove(),500);}}
@@ -12662,8 +13061,11 @@ _maybeOnboard();
 <div class="mo hidden" id="quick-add-modal" onclick="if(event.target===this)closeM('quick-add-modal')">
   <div class="md" style="width:460px;max-width:94vw;">
     <div class="mh"><h3>⚡ Quick Add Tasks</h3><button class="mc" aria-label="Close" onclick="closeM('quick-add-modal')">×</button></div>
-    <p style="font-size:12px;color:var(--muted);margin-bottom:8px;">One task per line — all land in Inbox</p>
-    <textarea id="qa-input" class="fc" style="min-height:120px;resize:vertical;" placeholder="Buy groceries&#10;Call dentist&#10;Ship onboarding fix #givelink   ← type #goal to link a task to a goal"></textarea>
+    <p style="font-size:12px;color:var(--muted);margin-bottom:8px;">One task per line · type <kbd>/</kbd> for commands · <kbd>#</kbd> to link a goal</p>
+    <div style="position:relative;">
+      <textarea id="qa-input" class="fc" style="min-height:120px;resize:vertical;" placeholder="Buy groceries&#10;Call dentist /tomorrow&#10;Ship onboarding fix /wealth #givelink" oninput="_qaSlash(this,event)" onkeydown="_qaSlashKey(this,event)"></textarea>
+      <div id="qa-slash" class="slash-menu" style="display:none;"></div>
+    </div>
     <div class="mf" style="margin-top:12px;">
       <button class="btn bg" onclick="closeM('quick-add-modal')">Cancel</button>
       <button class="btn bp" onclick="doQuickAdd()">Add to Inbox</button>

--- a/index.html
+++ b/index.html
@@ -753,6 +753,37 @@ body.light .seg-btn.active{background:#fff;}
 .ni:hover .ni-pin{opacity:.55;}
 .ni-pin:hover{opacity:1!important;color:var(--accent);background:var(--hover);}
 .ni-pin.pinned{opacity:.85;color:var(--accent);}
+/* ── AUTH GATE + HERO ───────────────────────────────────────────── */
+body.auth-locked{overflow:hidden;}
+.auth-gate{position:fixed;inset:0;z-index:100000;display:flex;align-items:center;justify-content:center;gap:56px;padding:40px 28px;background:radial-gradient(1200px 600px at 20% -10%,rgba(139,124,255,.16),transparent 60%),var(--bg);overflow-y:auto;flex-wrap:wrap;}
+.ag-hero-col{max-width:460px;flex:1 1 360px;min-width:0;}
+.ag-brand{display:flex;align-items:center;gap:10px;margin-bottom:26px;}
+.ag-word{font-size:20px;font-weight:800;letter-spacing:-.3px;}
+.ag-word .g{background:var(--brand-gradient);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;}
+.ag-hero{font-size:34px;line-height:1.15;font-weight:800;letter-spacing:-.8px;margin-bottom:16px;}
+.ag-sub{font-size:15px;line-height:1.6;color:var(--muted);margin-bottom:22px;}
+.ag-bullets{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:12px;}
+.ag-bullets li{font-size:13.5px;line-height:1.5;color:var(--text);padding-left:24px;position:relative;}
+.ag-bullets li::before{content:"✓";position:absolute;left:0;top:0;color:var(--accent);font-weight:800;}
+.ag-bullets b{font-weight:700;}
+.ag-card{flex:0 0 360px;max-width:360px;width:100%;background:var(--surface);border:1px solid var(--border);border-radius:18px;padding:28px 26px;box-shadow:0 20px 60px -20px rgba(0,0,0,.4);}
+.ag-card-title{font-size:20px;font-weight:800;margin-bottom:4px;}
+.ag-card-sub{font-size:13px;color:var(--muted);margin-bottom:18px;}
+.ag-input{width:100%;background:var(--surface2);border:1px solid var(--border);border-radius:10px;padding:12px 13px;color:var(--text);font:inherit;font-size:15px;outline:none;margin-bottom:10px;transition:border-color .12s,box-shadow .12s;}
+.ag-input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft);}
+.ag-err{color:#ef4444;font-size:12.5px;margin:2px 0 10px;line-height:1.4;}
+.ag-btn{width:100%;border:none;border-radius:10px;padding:12px;font:inherit;font-size:14.5px;font-weight:700;cursor:pointer;margin-top:4px;transition:filter .12s,background .12s;}
+.ag-primary{background:var(--brand-gradient);color:#fff;box-shadow:0 6px 18px -6px var(--accent);}
+.ag-primary:hover{filter:brightness(1.06);}
+.ag-primary:disabled{opacity:.6;cursor:default;}
+.ag-google{background:var(--surface2);color:var(--text);border:1px solid var(--border);margin-top:8px;}
+.ag-google:hover{background:var(--hover);}
+.ag-textlink{display:block;width:100%;background:none;border:none;color:var(--muted);font:inherit;font-size:12.5px;cursor:pointer;margin-top:12px;text-decoration:underline;text-underline-offset:2px;}
+.ag-textlink:hover{color:var(--accent);}
+.ag-toggle{text-align:center;font-size:13px;color:var(--muted);margin-top:16px;}
+.ag-toggle a{color:var(--accent);cursor:pointer;font-weight:600;}
+.ag-foot{text-align:center;font-size:11px;color:var(--muted);margin-top:18px;line-height:1.5;}
+@media(max-width:820px){.auth-gate{gap:28px;padding:32px 20px;}.ag-hero{font-size:27px;}.ag-hero-col{flex-basis:100%;text-align:center;}.ag-bullets{text-align:left;max-width:340px;margin:0 auto;}.ag-brand{justify-content:center;}}
 /* ── OURA RING ───────────────────────────────────────────────────── */
 .oura-ring{position:relative;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;}
 .oura-ring svg{position:absolute;top:0;left:0;transform:rotate(-90deg);}
@@ -775,6 +806,35 @@ body.light .seg-btn.active{background:#fff;}
 <div id="mobile-brand"><svg class="logo-mark" viewBox="0 0 32 32"><defs><linearGradient id="lgm2" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#8b7cff"/><stop offset="1" stop-color="#b681f5"/></linearGradient></defs><circle cx="16" cy="16" r="12" stroke="url(#lgm2)" stroke-width="3" fill="none"/><path d="M10 16.5 L14.5 21 L22 12" stroke="url(#lgm2)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span class="logo-word">Task<span class="g">OS</span></span></div>
 <span id="offline-pill" class="hidden" style="position:fixed;top:10px;right:14px;z-index:9999;background:#ef4444;color:#fff;font-size:11px;font-weight:700;padding:4px 10px;border-radius:20px;display:none;">📡 Offline</span>
 <input type="file" id="import-file-hidden" accept=".json" style="display:none;" onchange="importData(event)">
+
+<!-- ══ AUTH GATE + POSITIONING HERO (shown only when a hosted backend is configured) ══ -->
+<div id="auth-gate" class="auth-gate" style="display:none;">
+  <div class="ag-hero-col">
+    <div class="ag-brand">
+      <svg class="logo-mark" viewBox="0 0 32 32" width="30" height="30"><defs><linearGradient id="agl" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#8b7cff"/><stop offset="1" stop-color="#b681f5"/></linearGradient></defs><circle cx="16" cy="16" r="12" stroke="url(#agl)" stroke-width="3" fill="none"/><path d="M10 16.5 L14.5 21 L22 12" stroke="url(#agl)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+      <span class="ag-word">Task<span class="g">OS</span></span>
+    </div>
+    <h1 class="ag-hero">The calm, keyboard-fast home for everything you have to do.</h1>
+    <p class="ag-sub">Superhuman speed for your tasks. Notion depth for your life. AI that clears your inbox, plans your day, and keeps every task pointed at a goal.</p>
+    <ul class="ag-bullets">
+      <li><b>⌘K everything.</b> Reply to a task to do it. Triage your whole inbox with one tap.</li>
+      <li><b>It grows with you.</b> Goals, habits, weekly reviews and Oura-style rings — not just a list.</li>
+      <li><b>Yours, everywhere.</b> Syncs desktop ↔ mobile, works offline, export anytime.</li>
+    </ul>
+  </div>
+  <div class="ag-card">
+    <div class="ag-card-title" id="ag-title">Welcome back</div>
+    <div class="ag-card-sub" id="ag-subtitle">Log in to pick up where you left off.</div>
+    <input id="ag-email" class="ag-input" type="email" autocomplete="email" placeholder="you@email.com" onkeydown="if(event.key==='Enter')document.getElementById('ag-pass').focus()">
+    <input id="ag-pass" class="ag-input" type="password" autocomplete="current-password" placeholder="Password" onkeydown="if(event.key==='Enter')authSubmit()">
+    <div id="ag-err" class="ag-err" style="display:none;"></div>
+    <button class="ag-btn ag-primary" onclick="authSubmit()">Log in</button>
+    <button class="ag-btn ag-google" onclick="authGoogle()"><span style="font-weight:700;">G</span>&nbsp;Continue with Google</button>
+    <button class="ag-textlink" onclick="authMagic()">Email me a magic link instead</button>
+    <div class="ag-toggle">New to Task OS? <a onclick="_agToggleMode()"><span id="ag-mode-link">Create an account</span></a></div>
+    <div class="ag-foot">🔒 Your data is private (row-level secured) and yours to export anytime.</div>
+  </div>
+</div>
 
 <div class="s-ov" id="s-ov" onclick="toggleSB()"></div>
 
@@ -2770,6 +2830,7 @@ function nav(v){
   document.querySelector('.sidebar')?.classList.remove('open');
   document.getElementById('s-ov')?.classList.remove('open');
   document.querySelectorAll('.bni').forEach(b=>{b.classList.toggle('active',b.dataset.v===v);});
+  track('view_opened',{view:v});
 }
 // Restraint: strip leading emoji from view page titles (chrome, not content)
 function _stripH1Emoji(){
@@ -3625,7 +3686,7 @@ function saveTask(){
     return;
   }
   if(editT){const i=S.tasks.findIndex(t=>t.id===editT);S.tasks[i]={...S.tasks[i],...d};}
-  else S.tasks.push({id:uid(),...d,status:'todo',isT3:false,t3s:null,createdAt:new Date().toISOString(),completedAt:null});
+  else {S.tasks.push({id:uid(),...d,status:'todo',isT3:false,t3s:null,createdAt:new Date().toISOString(),completedAt:null});track('task_created',{via:'modal'});}
   save();closeM('tm');refresh();
 }
 
@@ -3661,6 +3722,7 @@ function toggleDone(id){
   t.completedAt=t.status==='done'?new Date().toISOString():null;
   if(t.status==='done'){
     t.isT3=false;t.t3s=null;_logContextSwitch(t.category);
+    track('task_completed',{category:t.category,bucket:t.bucket});
     _haptic(15);
     _fireConfetti(t.depth);
     _checkTaskMilestone();
@@ -4103,8 +4165,8 @@ function _nlDateResolve(s){
 async function _cmdkAI(input){
   closeCmdK();
   input=(input||'').trim();if(!input)return;
-  if(!S.claudeKey){toast('Add your Claude API key in Settings to use AI commands');return;}
-  toast('🤖 Interpreting…');
+  if(!S.claudeKey&&!APP_CONFIG.aiProxy){toast('Add your Claude API key in Settings to use AI commands');return;}
+  track('ai_command',{});toast('🤖 Interpreting…');
   const list=active().slice(0,60).map(t=>`${t.id} :: ${t.title}`).join('\n');
   const goals=(S.goals||[]).map(g=>({id:g.id,title:g.title}));
   const today=new Date().toISOString().slice(0,10);
@@ -4782,20 +4844,32 @@ function seedGoals(){
 
 // ── CALL CLAUDE ────────────────────────────────────────────────
 async function callClaude(prompt, maxTokens=1000){
-  if(!S.claudeKey){toast('Add Claude API key in Settings first');return null;}
+  const useProxy=!!APP_CONFIG.aiProxy;
+  if(!useProxy&&!S.claudeKey){toast('Add Claude API key in Settings first');return null;}
   try{
-    const res=await fetch('https://api.anthropic.com/v1/messages',{
-      method:'POST',
-      headers:{'Content-Type':'application/json','x-api-key':S.claudeKey,'anthropic-version':'2023-06-01','anthropic-dangerous-direct-browser-access':'true'},
-      body:JSON.stringify({model:'claude-haiku-4-5-20251001',max_tokens:maxTokens,messages:[{role:'user',content:prompt}]})
-    });
+    let res;
+    if(useProxy){
+      // Server-side proxy holds the key (users don't need their own). Auth with the Supabase token when signed in.
+      const tok=_sbEnabled()?await _sbToken().catch(()=>''):'';
+      res=await fetch(APP_CONFIG.aiProxy,{
+        method:'POST',
+        headers:{'Content-Type':'application/json',...(tok?{'Authorization':'Bearer '+tok}:{})},
+        body:JSON.stringify({prompt,max_tokens:maxTokens})
+      });
+    }else{
+      res=await fetch('https://api.anthropic.com/v1/messages',{
+        method:'POST',
+        headers:{'Content-Type':'application/json','x-api-key':S.claudeKey,'anthropic-version':'2023-06-01','anthropic-dangerous-direct-browser-access':'true'},
+        body:JSON.stringify({model:'claude-haiku-4-5-20251001',max_tokens:maxTokens,messages:[{role:'user',content:prompt}]})
+      });
+    }
     if(!res.ok){
       const err=await res.json().catch(()=>({}));
-      const msg=res.status===429?'Rate limit hit — wait a moment and try again':res.status===401?'Invalid API key — check Settings':(`AI error ${res.status}: `+(err.error?.message||res.statusText));
+      const msg=res.status===429?'Rate limit hit — wait a moment and try again':res.status===401?(useProxy?'Please sign in again':'Invalid API key — check Settings'):(`AI error ${res.status}: `+(err.error?.message||res.statusText));
       toast(msg);return null;
     }
     const data=await res.json();
-    return data.content?.[0]?.text||null;
+    return data.content?.[0]?.text||data.text||null;
   }catch(e){toast('AI error: '+e.message);return null;}
 }
 function showAiOut(title, text){
@@ -4810,7 +4884,7 @@ let _triageProposals=null;
 async function aiAutoTriage(){
   const inbox=S.tasks.filter(t=>t.bucket==='inbox'&&t.status!=='done');
   if(!inbox.length){toast('📥 Inbox is already clear!');return;}
-  if(!S.claudeKey){toast('Add your Claude API key in Settings to auto-triage');return;}
+  if(!S.claudeKey&&!APP_CONFIG.aiProxy){toast('Add your Claude API key in Settings to auto-triage');return;}
   if(!_aiLock('aiAutoTriage'))return;
   toast('✨ AI triaging your inbox…');
   const cats=Object.keys(CATS).join(', ');
@@ -4867,14 +4941,14 @@ function _applyTriage(){
     const t=S.tasks.find(x=>x.id===p.id);if(!t)return;
     t.bucket=p.bucket;t.category=p.category;n++;
   });
-  save();refresh();updIBadge();closeM('triage-modal');_haptic(15);
+  save();refresh();updIBadge();closeM('triage-modal');_haptic(15);track('triage_applied',{count:n});
   toast(`✨ Triaged ${n} task${n===1?'':'s'} out of your inbox`);
 }
 
 // ── PLAN MY DAY (AI drafts a focused, time-blocked today) ─────
 let _planDraft=null;
 async function aiPlanDay(){
-  if(!S.claudeKey){toast('Add your Claude API key in Settings to plan your day');return;}
+  if(!S.claudeKey&&!APP_CONFIG.aiProxy){toast('Add your Claude API key in Settings to plan your day');return;}
   const today=new Date().toISOString().slice(0,10);
   const top3GoalIds=(S.goals||[]).filter(g=>g.isTop3).map(g=>g.id);
   const scored=active().filter(t=>!_isSnoozed(t)).map(t=>{
@@ -4940,7 +5014,7 @@ function _applyPlan(){
     if(!t.dueDate)t.dueDate=today;
     n++;
   });
-  save();refresh();closeM('plan-modal');_haptic(15);
+  save();refresh();closeM('plan-modal');_haptic(15);track('plan_day_applied',{count:n});
   toast(n?`☀️ ${n} task${n===1?'':'s'} set as today's Top 3`:'Plan dismissed');
 }
 
@@ -6703,7 +6777,7 @@ function doQuickAdd(){
     if(goalId)_linked++;
     S.tasks.push({id:uid(),title,notes:'',bucket:sl.bucket,category:sl.category,urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:sl.dueDate,goalId:goalId||null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',read:false,createdAt:new Date().toISOString(),completedAt:null});
   });
-  save();refresh();closeM('quick-add-modal');toast(`Added ${lines.length} task${lines.length>1?'s':''}${_linked?' · '+_linked+' linked to a goal':''}`);
+  save();refresh();closeM('quick-add-modal');track('task_created',{via:'quick_add',count:lines.length});toast(`Added ${lines.length} task${lines.length>1?'s':''}${_linked?' · '+_linked+' linked to a goal':''}`);
 }
 
 // ════════════════════════════════════════════════════════════════
@@ -9701,9 +9775,31 @@ function getAboutMe(){return localStorage.getItem('taskos_about')||'';}
 // localStorage stays the instant offline cache; when connected, the full state
 // syncs to Supabase. Last-write-wins by S._updatedAt. Sync config lives in
 // localStorage (never inside the synced blob).
+/* ════════════════════════════════════════════════════════════════════════
+   APP CONFIG — fill these in ONCE to turn Task OS into a real product that
+   anyone can sign up for. Leave them blank to keep the current behaviour
+   (local-only / bring-your-own-Supabase, nothing changes).
+
+   1. Create a free project at supabase.com and run supabase-setup.sql.
+   2. Paste the project URL + anon (public) key below. The anon key is safe to
+      ship publicly — Row-Level Security keeps each account's data private.
+   3. In Supabase → Authentication → Providers, enable Email and Google.
+   4. (Optional) Deploy /api/claude.js on Vercel with your ANTHROPIC_API_KEY as
+      an env var, then paste its URL as aiProxy so users don't need their own
+      Claude key. Leave blank to keep the per-user key flow.
+   5. (Optional) Paste a PostHog project key to turn on product analytics.
+   ════════════════════════════════════════════════════════════════════════ */
+const APP_CONFIG={
+  supabaseUrl : '',   // e.g. 'https://abcd1234.supabase.co'
+  supabaseAnon: '',   // e.g. 'eyJhbGciOi...'  (public anon key)
+  aiProxy     : '',   // e.g. 'https://taskos.vercel.app/api/claude'
+  posthogKey  : '',   // e.g. 'phc_xxxxxxxx'
+  posthogHost : 'https://us.i.posthog.com',
+};
+function _hostedMode(){return !!(APP_CONFIG.supabaseUrl&&APP_CONFIG.supabaseAnon);}
 const _SB={
-  get url(){return (localStorage.getItem('taskos_sb_url')||'').replace(/\/+$/,'');},
-  get anon(){return localStorage.getItem('taskos_sb_anon')||'';},
+  get url(){return ((localStorage.getItem('taskos_sb_url')||APP_CONFIG.supabaseUrl||'')).replace(/\/+$/,'');},
+  get anon(){return localStorage.getItem('taskos_sb_anon')||APP_CONFIG.supabaseAnon||'';},
   get email(){return localStorage.getItem('taskos_sb_email')||'';},
   get access(){return localStorage.getItem('taskos_sb_access')||'';},
   get refresh(){return localStorage.getItem('taskos_sb_refresh')||'';},
@@ -9733,7 +9829,8 @@ function _openSyncMenu(ev){
   if(_sbEnabled())opts.push(['🔄 Sync now',"sbSyncNow(true)"]);
   opts.push(['⬇ Download backup','exportData()']);
   opts.push(['⬆ Restore from backup',"document.getElementById('import-file-hidden').click()"]);
-  opts.push(['☁ Sync settings','openSettings()']);
+  if(!_hostedMode())opts.push(['☁ Sync settings','openSettings()']);
+  if(_hostedMode()&&_sbEnabled())opts.push(['🚪 Sign out','authLogout()']);
   let el=document.getElementById('sync-menu');
   if(!el){el=document.createElement('div');el.id='sync-menu';el.className='slash-menu';el.style.cssText='position:fixed;z-index:2000;min-width:210px;';document.body.appendChild(el);document.addEventListener('click',e=>{if(el&&!el.contains(e.target)&&e.target.id!=='sync-pill'&&!e.target.closest('#sync-pill'))el.style.display='none';});}
   el.innerHTML=opts.map(([label,fn])=>`<div class="slash-item" onclick="event.stopPropagation();document.getElementById('sync-menu').style.display='none';${fn}"><span>${label}</span></div>`).join('');
@@ -9793,6 +9890,105 @@ function sbDisconnect(){
   ['access','refresh','exp','uid'].forEach(k=>localStorage.removeItem('taskos_sb_'+k));
   _sbSetStatus('Disconnected');toast('Cloud sync disconnected (local data kept)');
 }
+// ══ HOSTED AUTH (signup / login / magic link / Google) ══
+let _agMode='login';
+function _showAuthGate(){const g=document.getElementById('auth-gate');if(!g)return;g.style.display='flex';document.body.classList.add('auth-locked');const s=document.getElementById('app-splash');if(s){s.classList.add('hide');}}
+function _hideAuthGate(){const g=document.getElementById('auth-gate');if(g)g.style.display='none';document.body.classList.remove('auth-locked');}
+function _agToggleMode(){
+  _agMode=_agMode==='login'?'signup':'login';
+  const login=_agMode==='login';
+  document.getElementById('ag-title').textContent=login?'Welcome back':'Create your account';
+  document.getElementById('ag-subtitle').textContent=login?'Log in to pick up where you left off.':'Free to start — no credit card.';
+  document.querySelector('#auth-gate .ag-primary').textContent=login?'Log in':'Sign up';
+  document.getElementById('ag-mode-link').textContent=login?'Create an account':'I already have an account';
+  document.getElementById('ag-pass').setAttribute('autocomplete',login?'current-password':'new-password');
+  _agErr('');
+}
+function _agErr(m){const e=document.getElementById('ag-err');if(!e)return;e.textContent=m||'';e.style.display=m?'block':'none';}
+async function authSubmit(){
+  const email=(document.getElementById('ag-email').value||'').trim();
+  const pass=document.getElementById('ag-pass').value||'';
+  if(!email||!pass){_agErr('Enter your email and a password');return;}
+  if(_agMode==='signup'&&pass.length<6){_agErr('Use at least 6 characters for your password');return;}
+  _agErr('');const btn=document.querySelector('#auth-gate .ag-primary');btn.disabled=true;const label=btn.textContent;btn.textContent='…';
+  try{
+    let j;
+    if(_agMode==='signup'){
+      const r=await fetch(`${_SB.url}/auth/v1/signup`,{method:'POST',headers:{'Content-Type':'application/json','apikey':_SB.anon},body:JSON.stringify({email,password:pass})});
+      j=await r.json().catch(()=>({}));
+      if(!r.ok)throw new Error(j.msg||j.error_description||j.error||('Sign-up failed ('+r.status+')'));
+      if(!j.access_token){_agErr('Almost there — check your email to confirm, then log in.');btn.disabled=false;btn.textContent=label;return;}
+    }else{
+      j=await _sbAuth('password',{email,password:pass});
+    }
+    localStorage.setItem('taskos_sb_email',email);
+    _sbStoreSession(j);
+    track('auth_'+_agMode,{method:'password'});
+    await _afterAuth();
+  }catch(e){
+    _agErr(_agMode==='login'?'Wrong email or password — or confirm your email first.':e.message);
+    btn.disabled=false;btn.textContent=label;
+  }
+}
+async function authMagic(){
+  const email=(document.getElementById('ag-email').value||'').trim();
+  if(!email){_agErr('Enter your email first, then I’ll send the link');return;}
+  try{
+    const r=await fetch(`${_SB.url}/auth/v1/otp`,{method:'POST',headers:{'Content-Type':'application/json','apikey':_SB.anon},body:JSON.stringify({email,create_user:true})});
+    if(!r.ok)throw new Error('send failed');
+    localStorage.setItem('taskos_sb_email',email);
+    _agErr('');track('auth_magic_sent',{});
+    toast('✉️ Magic link sent — check your inbox');
+  }catch(e){_agErr('Could not send the link — try again in a moment');}
+}
+function authGoogle(){
+  const redirect=encodeURIComponent(location.origin+location.pathname);
+  track('auth_google_start',{});
+  location.href=`${_SB.url}/auth/v1/authorize?provider=google&redirect_to=${redirect}`;
+}
+function authLogout(){
+  ['access','refresh','exp','uid'].forEach(k=>localStorage.removeItem('taskos_sb_'+k));
+  track('auth_logout',{});
+  try{if(window.posthog&&posthog.reset)posthog.reset();}catch(e){}
+  if(_hostedMode())location.reload();else toast('Signed out (local data kept)');
+}
+async function _afterAuth(){
+  _hideAuthGate();
+  _phIdentify();
+  try{await sbSyncNow(true);}catch(e){}
+  try{refresh();}catch(e){}
+  _sbRenderPill();
+  toast('👋 Welcome to Task OS');
+}
+// Handle magic-link / OAuth redirect tokens in the URL hash, then show the gate if needed.
+async function _authBoot(){
+  if(!_hostedMode())return; // local / bring-your-own mode: nothing changes
+  const h=location.hash||'';
+  if(h.includes('access_token=')){
+    const p=new URLSearchParams(h.replace(/^#/,''));
+    const at=p.get('access_token'),rt=p.get('refresh_token'),ei=parseInt(p.get('expires_in')||'3600');
+    if(at){
+      localStorage.setItem('taskos_sb_access',at);
+      if(rt)localStorage.setItem('taskos_sb_refresh',rt);
+      localStorage.setItem('taskos_sb_exp',String(Date.now()+ei*1000));
+      try{const r=await fetch(`${_SB.url}/auth/v1/user`,{headers:{'apikey':_SB.anon,'Authorization':'Bearer '+at}});const u=await r.json();if(u&&u.id){localStorage.setItem('taskos_sb_uid',u.id);if(u.email)localStorage.setItem('taskos_sb_email',u.email);}}catch(e){}
+      history.replaceState(null,'',location.pathname+location.search);
+      track('auth_oauth',{});
+      await _afterAuth();
+      return;
+    }
+  }
+  if(_sbEnabled()){_hideAuthGate();try{sbSyncNow();}catch(e){}}
+  else{_showAuthGate();}
+}
+// ══ PRODUCT ANALYTICS (PostHog) — no-ops entirely unless a key is configured ══
+function _initPostHog(){
+  if(!APP_CONFIG.posthogKey||window.__phInit)return;window.__phInit=1;
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  try{posthog.init(APP_CONFIG.posthogKey,{api_host:APP_CONFIG.posthogHost,persistence:'localStorage',autocapture:false,capture_pageview:true});_phIdentify();}catch(e){}
+}
+function track(ev,props){try{if(window.posthog&&posthog.capture)posthog.capture(ev,props||{});}catch(e){}}
+function _phIdentify(){try{if(window.posthog&&posthog.identify&&_SB.uid)posthog.identify(_SB.uid,{email:_SB.email});}catch(e){}}
 async function sbPull(){
   const tok=await _sbToken();
   const r=await fetch(`${_SB.url}/rest/v1/app_state?user_id=eq.${_SB.uid}&select=data,updated_at`,{headers:{'apikey':_SB.anon,'Authorization':'Bearer '+tok}});
@@ -12976,6 +13172,8 @@ _initPullRefresh();
 _initSheetDismiss();
 _maybeOnboard();
 try{_renderSavedViews();_updateUnreadBadges();_addPinStars();_renderPinnedViews();}catch(e){}
+try{_initPostHog();}catch(e){}
+try{_authBoot();}catch(e){}
 // Fade out the launch splash once the app has painted (with a safety fallback)
 (function(){
   function _hideSplash(){const s=document.getElementById('app-splash');if(s&&!s.classList.contains('hide')){s.classList.add('hide');setTimeout(()=>s.remove(),500);}}

--- a/index.html
+++ b/index.html
@@ -9790,8 +9790,8 @@ function getAboutMe(){return localStorage.getItem('taskos_about')||'';}
    5. (Optional) Paste a PostHog project key to turn on product analytics.
    ════════════════════════════════════════════════════════════════════════ */
 const APP_CONFIG={
-  supabaseUrl : '',   // e.g. 'https://abcd1234.supabase.co'
-  supabaseAnon: '',   // e.g. 'eyJhbGciOi...'  (public anon key)
+  supabaseUrl : 'https://bgvddpkdsftgynxyhnoc.supabase.co',   // your Supabase Project URL
+  supabaseAnon: 'sb_publishable_VndetAqTYLRXr4UEsu8Uig_y2mtTv-M', // publishable (public) key — safe in the browser; RLS protects data
   aiProxy     : '',   // e.g. 'https://taskos.vercel.app/api/claude'
   posthogKey  : '',   // e.g. 'phc_xxxxxxxx'
   posthogHost : 'https://us.i.posthog.com',

--- a/index.html
+++ b/index.html
@@ -737,6 +737,22 @@ body.light .seg-btn.active{background:#fff;}
 .sv-row .sv-x{margin-left:auto;opacity:0;font-size:14px;color:var(--muted);}
 .sv-row:hover .sv-x{opacity:.7;}
 .sv-star{flex:none;color:var(--accent);font-size:11px;}
+/* ── SYNC PILL ──────────────────────────────────────────────────── */
+.sync-pill{display:flex;align-items:center;gap:8px;margin:8px 10px 4px;padding:6px 10px;border-radius:8px;background:var(--surface2);border:1px solid var(--border);font-size:11.5px;font-weight:600;color:var(--muted);cursor:pointer;transition:background .12s;-webkit-tap-highlight-color:transparent;}
+.sync-pill:hover{background:var(--hover);}
+.sync-dot{width:8px;height:8px;border-radius:50%;flex:none;background:var(--muted);transition:background .2s;}
+.sync-pill.ok .sync-dot{background:#7ee0a0;}
+.sync-pill.syncing .sync-dot{background:#ffc078;animation:syncPulse 1s ease-in-out infinite;}
+.sync-pill.err .sync-dot{background:#ef4444;}
+.sync-pill.offline .sync-dot{background:#ff8a8a;}
+@keyframes syncPulse{0%,100%{opacity:1;}50%{opacity:.3;}}
+.sidebar-filter{margin:2px 10px 6px;width:calc(100% - 20px);background:var(--surface2);border:1px solid var(--border);border-radius:8px;padding:6px 10px;color:var(--text);font:inherit;font-size:12.5px;outline:none;transition:border-color .12s;}
+.sidebar-filter:focus{border-color:var(--accent);}
+.ni.sf-hidden{display:none!important;}
+.ni-pin{position:absolute;right:8px;top:50%;transform:translateY(-50%);font-size:12px;color:var(--muted);opacity:0;transition:opacity .12s,color .12s;cursor:pointer;padding:2px 4px;border-radius:4px;}
+.ni:hover .ni-pin{opacity:.55;}
+.ni-pin:hover{opacity:1!important;color:var(--accent);background:var(--hover);}
+.ni-pin.pinned{opacity:.85;color:var(--accent);}
 /* ── OURA RING ───────────────────────────────────────────────────── */
 .oura-ring{position:relative;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;}
 .oura-ring svg{position:absolute;top:0;left:0;transform:rotate(-90deg);}
@@ -758,6 +774,8 @@ body.light .seg-btn.active{background:#fff;}
 <button class="mob-search" onclick="openCmdK()" aria-label="Search and commands">🔍</button>
 <div id="mobile-brand"><svg class="logo-mark" viewBox="0 0 32 32"><defs><linearGradient id="lgm2" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#8b7cff"/><stop offset="1" stop-color="#b681f5"/></linearGradient></defs><circle cx="16" cy="16" r="12" stroke="url(#lgm2)" stroke-width="3" fill="none"/><path d="M10 16.5 L14.5 21 L22 12" stroke="url(#lgm2)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg><span class="logo-word">Task<span class="g">OS</span></span></div>
 <span id="offline-pill" class="hidden" style="position:fixed;top:10px;right:14px;z-index:9999;background:#ef4444;color:#fff;font-size:11px;font-weight:700;padding:4px 10px;border-radius:20px;display:none;">📡 Offline</span>
+<input type="file" id="import-file-hidden" accept=".json" style="display:none;" onchange="importData(event)">
+
 <div class="s-ov" id="s-ov" onclick="toggleSB()"></div>
 
 <nav class="sidebar">
@@ -772,6 +790,12 @@ body.light .seg-btn.active{background:#fff;}
   <div class="cmdk-chip" onclick="openCmdK()" title="Command palette — search, navigate, capture">
     <span style="font-size:13px;">🔍</span><span>Quick find…</span>
     <span class="ck-keys"><kbd>⌘</kbd><kbd>K</kbd></span>
+  </div>
+  <div id="sync-pill" class="sync-pill" onclick="_openSyncMenu(event)" title="Sync status — click for options"><span class="sync-dot"></span><span id="sync-pill-txt">Local only</span></div>
+  <input id="sidebar-filter" class="sidebar-filter" placeholder="Filter menu…" oninput="_filterSidebar(this.value)" aria-label="Filter navigation">
+  <div id="pinned-group" class="ns-group" data-ns="pinned" style="display:none;">
+  <span class="ns" style="cursor:default;">Pinned</span>
+  <div id="pinned-views"></div>
   </div>
   <div id="saved-views-group" class="ns-group" data-ns="views" style="display:none;">
   <span class="ns" onclick="_toggleNsGroup(this)">Views<span class="ns-arrow">▾</span></span>
@@ -856,6 +880,7 @@ body.light .seg-btn.active{background:#fff;}
         <span id="xp-label">0 XP</span>
       </div>
       <button class="btn bg sm" id="start-day-btn" onclick="openStartDay()" style="display:none;">☀️ Start Day</button>
+      <button class="btn bp sm" onclick="aiPlanDay()" title="AI drafts a focused, time-blocked plan for today">☀️ Plan my day</button>
       <button class="cmdk-chip-h" onclick="openCmdK()" title="Command palette — search, navigate, capture">🔍 <span>Search</span> <kbd>⌘K</kbd></button>
       <button class="btn bg sm dash-extra" onclick="openChecklist('daily')" id="checklist-btn" title="Daily / Weekly / Monthly Checklist">📋 <span id="checklist-badge" style="display:none;background:#ef4444;color:#fff;border-radius:8px;padding:0 5px;font-size:10px;font-weight:700;"></span></button>
       <button class="btn bg sm dash-extra" onclick="openReminderSettings()" title="Reminders" id="remind-btn">🔔</button>
@@ -2379,6 +2404,31 @@ function exportData(){
   a.click();URL.revokeObjectURL(a.href);
   toast('✅ Data exported!');
 }
+// Export dated tasks as an .ics file any calendar app can import (one-way;
+// true 2-way Google Calendar sync would require OAuth + a server component).
+function exportICS(){
+  const tasks=S.tasks.filter(t=>t.dueDate&&t.status!=='done');
+  if(!tasks.length){toast('No tasks with a due date to export yet');return;}
+  const dtstamp=new Date().toISOString().replace(/[-:]/g,'').split('.')[0]+'Z';
+  const ie=s=>String(s||'').replace(/([,;\\])/g,'\\$1').replace(/\r?\n/g,'\\n');
+  const lines=['BEGIN:VCALENDAR','VERSION:2.0','PRODID:-//TaskOS//Personal OS//EN','CALSCALE:GREGORIAN','METHOD:PUBLISH','X-WR-CALNAME:Task OS'];
+  tasks.forEach(t=>{
+    const start=t.dueDate.replace(/-/g,'');
+    const nd=new Date(t.dueDate+'T00:00');nd.setDate(nd.getDate()+1);
+    const end=nd.toISOString().slice(0,10).replace(/-/g,'');
+    const cat=CATS[t.category]?.l||'';
+    lines.push('BEGIN:VEVENT','UID:'+t.id+'@taskos','DTSTAMP:'+dtstamp,
+      'DTSTART;VALUE=DATE:'+start,'DTEND;VALUE=DATE:'+end,
+      'SUMMARY:'+ie((t.isT3?'★ ':'')+t.title),
+      'DESCRIPTION:'+ie((cat?('['+cat+'] '):'')+(t.notes||'')),
+      'END:VEVENT');
+  });
+  lines.push('END:VCALENDAR');
+  const blob=new Blob([lines.join('\r\n')],{type:'text/calendar'});
+  const a=document.createElement('a');a.href=URL.createObjectURL(blob);
+  a.download='taskos-'+new Date().toISOString().slice(0,10)+'.ics';a.click();URL.revokeObjectURL(a.href);
+  toast('🗓️ Exported '+tasks.length+' dated task'+(tasks.length===1?'':'s')+' — import the .ics into Google/Apple Calendar');
+}
 function importData(e){
   const file=e.target.files[0];if(!file)return;
   const reader=new FileReader();
@@ -3059,11 +3109,18 @@ function renderEisenhower(){
 }
 
 // ── ALL TASKS ─────────────────────────────────────────────────
-function setF(cat,el){fCat=cat;sessionStorage.setItem('taskos_fcat',fCat);document.querySelectorAll('.fp').forEach(p=>p.classList.remove('active'));el.classList.add('active');renderAll();}
+function setF(cat,el){fCat=cat;sessionStorage.setItem('taskos_fcat',fCat);_allWindow=60;document.querySelectorAll('.fp').forEach(p=>p.classList.remove('active'));el.classList.add('active');renderAll();}
 
 let _allMode=localStorage.getItem('taskos_allmode')||'list';
+let _allWindow=60,_allIO=null;
+function _observeAllSentinel(){
+  const s=document.getElementById('all-sentinel');if(!s)return;
+  if(_allIO)_allIO.disconnect();
+  _allIO=new IntersectionObserver(es=>{if(es.some(e=>e.isIntersecting)){_allWindow+=80;renderAll();}},{rootMargin:'400px'});
+  _allIO.observe(s);
+}
 function setAllMode(m){
-  _allMode=m;localStorage.setItem('taskos_allmode',m);
+  _allMode=m;localStorage.setItem('taskos_allmode',m);_allWindow=60;
   document.querySelectorAll('#all-seg .seg-btn').forEach(b=>b.classList.toggle('active',b.dataset.mode===m));
   const pane=document.querySelector('.all-two-pane');if(pane)pane.classList.toggle('single',m!=='list');
   _haptic(6);renderAll();
@@ -3102,6 +3159,52 @@ function _renderSavedViews(){
   group.style.display=vs.length?'':'none';
   wrap.innerHTML=vs.map(v=>`<div class="sv-row" onclick="_openSavedView('${v.id}')" title="${esc(v.name)}"><span class="sv-star">★</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${esc(v.name)}</span><span class="sv-x" onclick="_deleteSavedView('${v.id}',event)" title="Remove">×</span></div>`).join('');
 }
+// ── SIDEBAR: pinned views, live filter, pin/unpin (calm through subtraction) ──
+const _DEFAULT_PINS=['dashboard','all','capture','goals','focus','habits','review','calendar'];
+function _getPins(){return Array.isArray(S.pinnedViews)?S.pinnedViews:_DEFAULT_PINS;}
+function _niLabel(el){let s='';el.childNodes.forEach(n=>{if(n.nodeType===3)s+=n.textContent;});return s.trim();}
+function _niIcon(el){return el.querySelector('.ni-ic')?.textContent||'';}
+function _togglePin(v,ev){
+  ev&&ev.stopPropagation();
+  let p=[..._getPins()];
+  if(p.includes(v))p=p.filter(x=>x!==v);else p.push(v);
+  S.pinnedViews=p;save();_renderPinnedViews();_addPinStars();
+}
+function _renderPinnedViews(){
+  const wrap=document.getElementById('pinned-views'),group=document.getElementById('pinned-group');if(!wrap||!group)return;
+  const pins=_getPins();
+  const rows=pins.map(v=>{
+    const src=document.querySelector('.sidebar .ns-group:not([data-ns="pinned"]) .ni[data-v="'+v+'"]');
+    if(!src)return '';
+    return `<div class="ni" data-v="${v}" data-pinclone="1" onclick="nav('${v}')"><span class="ni-ic">${_niIcon(src)}</span>${esc(_niLabel(src))}<span class="ni-pin pinned" title="Unpin" onclick="_togglePin('${v}',event)">★</span></div>`;
+  }).filter(Boolean).join('');
+  group.style.display=rows?'':'none';
+  wrap.innerHTML=rows;
+  // reflect active state
+  const cur=localStorage.getItem('taskos_lastview');
+  wrap.querySelectorAll('.ni').forEach(el=>el.classList.toggle('active',el.dataset.v===cur));
+}
+function _addPinStars(){
+  const pins=_getPins();
+  document.querySelectorAll('.sidebar .ns-group:not([data-ns="pinned"]):not([data-ns="views"]) .ni[data-v]').forEach(el=>{
+    let star=el.querySelector('.ni-pin');
+    if(!star){star=document.createElement('span');star.className='ni-pin';el.appendChild(star);star.addEventListener('click',e=>_togglePin(el.dataset.v,e));}
+    const on=pins.includes(el.dataset.v);
+    star.textContent=on?'★':'☆';star.title=on?'Unpin':'Pin to top';star.classList.toggle('pinned',on);
+  });
+}
+function _filterSidebar(q){
+  q=(q||'').toLowerCase().trim();
+  if(q)document.querySelectorAll('.sidebar .ns-group').forEach(g=>{g.classList.remove('collapsed');const a=g.querySelector('.ns-arrow');if(a)a.textContent='▾';});
+  document.querySelectorAll('.sidebar .ns-group:not([data-ns="pinned"]) .ni[data-v]').forEach(el=>{
+    el.classList.toggle('sf-hidden',!!q&&!_niLabel(el).toLowerCase().includes(q));
+  });
+  // hide group headers whose items are all filtered out
+  document.querySelectorAll('.sidebar .ns-group:not([data-ns="pinned"]):not([data-ns="views"])').forEach(g=>{
+    const anyVisible=[...g.querySelectorAll('.ni[data-v]')].some(el=>!el.classList.contains('sf-hidden'));
+    g.style.display=(q&&!anyVisible)?'none':'';
+  });
+}
 function _allFilteredTasks(){
   const q=document.getElementById('srch')?.value?.toLowerCase()||'';
   let tasks=[...S.tasks];
@@ -3124,15 +3227,22 @@ function renderAll(){
   if(!tasks.length){document.getElementById('all-list').innerHTML=_empty('✅','No tasks here','Add your first task or adjust the filter above.','<button class="btn bp sm" onclick="openAdd()">+ Add Task</button>');_selTaskId=null;renderReadingPane(null);return;}
   const grouped={};
   tasks.forEach(t=>{const k=t.status==='done'?'done':t.bucket;(grouped[k]=grouped[k]||[]).push(t);});
-  let html='';
+  // Performance: only render up to _allWindow rows; a sentinel loads more on scroll.
+  let html='',rendered=0,truncated=false;
   ['inbox','this-week','this-month','backlog','someday','done'].forEach(k=>{
     if(!grouped[k]?.length)return;
+    if(rendered>=_allWindow){truncated=true;return;}
     const b=k==='done'?{l:'Completed',e:'✅'}:BKTS[k];
+    const slice=grouped[k].slice(0,_allWindow-rendered);
+    if(slice.length<grouped[k].length)truncated=true;
     html+=`<h3 style="margin:14px 0 7px;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.4px;">${b.e} ${b.l} (${grouped[k].length})</h3>`;
-    html+=grouped[k].map(t=>tcHTML(t)).join('');
+    html+=slice.map(t=>tcHTML(t)).join('');
+    rendered+=slice.length;
   });
+  if(truncated)html+=`<div id="all-sentinel" style="text-align:center;padding:14px;color:var(--muted);font-size:12px;">Showing ${rendered} of ${tasks.length} — <a onclick="_allWindow+=200;renderAll()" style="color:var(--accent);cursor:pointer;">show all</a></div>`;
   document.getElementById('all-list').innerHTML=html;
   setTimeout(_attachSwipes,0);
+  if(truncated)_observeAllSentinel();
   // Two-pane reading view (desktop only): keep selection valid, default to first task, refresh pane.
   // On mobile the pane is hidden, so we must NOT auto-open (which would mark the top task read).
   if(document.getElementById('reading-pane')&&window.innerWidth>=1000){
@@ -3193,7 +3303,7 @@ function renderAllCalendar(tasks){
     dayList=`<div class="cal-daylist"><h4>Tap a day to see what's due</h4><div style="font-size:12px;color:var(--muted);line-height:1.6;">${undated} active task${undated===1?'':'s'} have no due date. Open one and set a date to place it on the calendar.</div></div>`;
   }
   document.getElementById('all-list').innerHTML=`<div class="cal-wrap">
-    <div class="cal-head"><div class="cal-title">${monthLabel}</div><div class="cal-nav"><button onclick="_calShift(-1)" aria-label="Previous month">‹</button><button onclick="_calShift(1)" aria-label="Next month">›</button></div></div>
+    <div class="cal-head"><div class="cal-title">${monthLabel}</div><div class="cal-nav"><button class="btn bg sm" style="width:auto;padding:0 12px;" onclick="exportICS()" title="Export dated tasks as a calendar file">🗓️ Export .ics</button><button onclick="_calShift(-1)" aria-label="Previous month">‹</button><button onclick="_calShift(1)" aria-label="Next month">›</button></div></div>
     <div class="cal-grid">${dows.map(d=>`<div class="cal-dow">${d}</div>`).join('')}${cells}</div>
     ${dayList}
   </div>`;
@@ -3520,7 +3630,7 @@ function saveTask(){
 }
 
 let _searchTimer=null;
-function _debouncedSearch(){clearTimeout(_searchTimer);_searchTimer=setTimeout(renderAll,150);}
+function _debouncedSearch(){clearTimeout(_searchTimer);_searchTimer=setTimeout(()=>{_allWindow=60;renderAll();},150);}
 let _undoTask=null,_undoTimer=null;
 function delTask(id){
   const t=S.tasks.find(x=>x.id===id);if(!t)return;
@@ -3878,6 +3988,7 @@ function _cmdkSearch(){
     const cmds=_cmdkCommands().filter(c=>c.label.toLowerCase().includes(q)).slice(0,8);
     const tasks=active().filter(t=>t.title.toLowerCase().includes(q)).slice(0,5).map(t=>({ic:'✅',label:t.title,sub:'Task',run:()=>{closeCmdK();openEdit(t.id);}}));
     items=[...cmds,...tasks];
+    if(q.length>=3)items.push({ic:'🤖',label:'Ask AI: “'+q+'”',sub:'AI',run:()=>_cmdkAI(document.getElementById('cmdk-i').value)});
   }
   _cmdkItems=items;_cmdkIdx=0;
   if(!items.length){box.innerHTML='<div class="cmdk-res-empty">No matches — press <kbd>Enter</kbd> to capture "'+esc(q)+'"</div>';return;}
@@ -3958,7 +4069,65 @@ function _handleCmdKNL(input){
     const t=S.tasks.find(x=>x.status!=='done'&&x.title.toLowerCase().includes(q));
     if(t&&bkt){mvB(t.id,bkt);closeCmdK();toast(`Moved "${t.title}" to ${bkt}`);return true;}
   }
+  // "snooze [task] [to] [when]"
+  const snz=lower.match(/^snooze\s+(.+?)\s+(?:to\s+|till\s+|until\s+)?([a-z0-9 -]+)$/);
+  if(snz){
+    const q=snz[1].trim();const d=_nlDateResolve(snz[2].trim());
+    const t=d&&S.tasks.find(x=>x.status!=='done'&&x.title.toLowerCase().includes(q));
+    if(t&&d){snoozeTask(t.id,d);closeCmdK();return true;}
+  }
+  // "[task] due [when]"
+  const dueM=lower.match(/^(.+?)\s+due\s+(.+)$/);
+  if(dueM){
+    const q=dueM[1].trim();const d=_nlDateResolve(dueM[2].trim());
+    const t=d&&S.tasks.find(x=>x.status!=='done'&&x.title.toLowerCase().includes(q));
+    if(t&&d){t.dueDate=d.toISOString().slice(0,10);if(t.bucket==='inbox')t.bucket='this-week';save();refresh();closeCmdK();toast('📅 '+t.title+' due '+fd(t.dueDate));return true;}
+  }
   return false;
+}
+// Resolve a natural-language date phrase → Date (used by ⌘K commands)
+function _nlDateResolve(s){
+  s=(s||'').toLowerCase().trim();
+  if(/^today$/.test(s))return _snoozeAt(0,9);
+  if(/^tonight$/.test(s))return _snoozeAt(0,21);
+  if(/^tomorrow$/.test(s))return _snoozeAt(1,9);
+  if(/weekend/.test(s))return _nextWeekendD();
+  if(/next week/.test(s))return _nextMondayD();
+  const inDays=s.match(/in (\d+) days?/);if(inDays)return _snoozeAt(parseInt(inDays[1]),9);
+  const days={sunday:0,monday:1,tuesday:2,wednesday:3,thursday:4,friday:5,saturday:6,sun:0,mon:1,tue:2,wed:3,thu:4,fri:5,sat:6};
+  for(const k in days){if(s===k||s==='next '+k){const d=new Date();let add=(days[k]-d.getDay()+7)%7;if(add===0)add=7;d.setDate(d.getDate()+add);d.setHours(9,0,0,0);return d;}}
+  const iso=s.match(/\d{4}-\d{2}-\d{2}/);if(iso){const d=new Date(iso[0]+'T09:00');if(!isNaN(d))return d;}
+  return null;
+}
+// AI-interpret a free-text ⌘K command into a single task action
+async function _cmdkAI(input){
+  closeCmdK();
+  input=(input||'').trim();if(!input)return;
+  if(!S.claudeKey){toast('Add your Claude API key in Settings to use AI commands');return;}
+  toast('🤖 Interpreting…');
+  const list=active().slice(0,60).map(t=>`${t.id} :: ${t.title}`).join('\n');
+  const goals=(S.goals||[]).map(g=>({id:g.id,title:g.title}));
+  const today=new Date().toISOString().slice(0,10);
+  const prompt=`Turn this command into ONE JSON action for a task app. Actions:
+{"action":"complete","id":"..."} {"action":"snooze","id":"...","date":"YYYY-MM-DD"} {"action":"move","id":"...","bucket":"this-week|this-month|backlog|someday|inbox"} {"action":"due","id":"...","date":"YYYY-MM-DD"} {"action":"rename","id":"...","title":"..."} {"action":"link_goal","id":"...","goalId":"..."} {"action":"open","id":"..."} {"action":"add","title":"..."}
+If it references an existing task, match by meaning and include its "id" from the list. For "add", omit id.
+TODAY: ${today}
+GOALS: ${JSON.stringify(goals)}
+TASKS (id :: title):
+${list}
+COMMAND: "${input}"
+Return ONLY the JSON, no prose.`;
+  const raw=await callClaude(prompt,300);
+  if(!raw)return;
+  let act;try{act=JSON.parse((raw.match(/\{[\s\S]*\}/)||[])[0]);}catch(e){toast('Could not interpret that command');return;}
+  if(act.action==='add'){
+    const title=(act.title||input).trim();
+    S.tasks.push({id:uid(),title,notes:'',bucket:'inbox',category:'other',urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:'',goalId:null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',read:false,createdAt:new Date().toISOString(),completedAt:null});
+    save();refresh();updIBadge();toast('➕ Added: '+title);return;
+  }
+  if(act.action==='open'){if(act.id&&S.tasks.find(x=>x.id===act.id))openTaskDrawer(act.id);else toast('No task matched');return;}
+  if(!act.id||!S.tasks.find(x=>x.id===act.id)){toast('Couldn’t match a task for that');return;}
+  _applyTaskAction(act.id,act);refresh();
 }
 
 // ── FOCUS NOW ─────────────────────────────────────────────────
@@ -4700,6 +4869,79 @@ function _applyTriage(){
   });
   save();refresh();updIBadge();closeM('triage-modal');_haptic(15);
   toast(`✨ Triaged ${n} task${n===1?'':'s'} out of your inbox`);
+}
+
+// ── PLAN MY DAY (AI drafts a focused, time-blocked today) ─────
+let _planDraft=null;
+async function aiPlanDay(){
+  if(!S.claudeKey){toast('Add your Claude API key in Settings to plan your day');return;}
+  const today=new Date().toISOString().slice(0,10);
+  const top3GoalIds=(S.goals||[]).filter(g=>g.isTop3).map(g=>g.id);
+  const scored=active().filter(t=>!_isSnoozed(t)).map(t=>{
+    let s=0;
+    if(t.dueDate&&t.dueDate<today)s+=100;
+    if(t.dueDate===today)s+=80;
+    if(t.isT3)s+=60;
+    if(t.goalId&&top3GoalIds.includes(t.goalId))s+=40;
+    if(t.bucket==='this-week')s+=20;
+    if(t.bucket==='inbox')s+=5;
+    if(t.importance==='high')s+=10;
+    return {t,s};
+  }).filter(x=>x.s>0).sort((a,b)=>b.s-a.s).slice(0,22).map(x=>x.t);
+  if(!scored.length){toast('Nothing pressing today — your inbox is calm ✨');return;}
+  if(!_aiLock('aiPlanDay'))return;
+  toast('☀️ Drafting your day…');
+  const hour=new Date().getHours();
+  const list=scored.map(t=>`${t.id} :: ${t.title}${t.dueDate?(' (due '+t.dueDate+')'):''}${t.goalId?' [goal]':''}`).join('\n');
+  const prompt=`You are a calm, sharp productivity coach. Plan a realistic, focused TODAY from these candidate tasks. It is about ${hour}:00 now.
+Pick the 3 highest-leverage as "top3". Then propose an ordered schedule of at most 6 items — protect focus, do NOT overload the day. Give each a rough time block (e.g. "9–11am").
+TASKS (id :: title):
+${list}
+Return ONLY JSON: {"top3":["id","id","id"],"plan":[{"id":"...","block":"9–11am","why":"one short reason"}],"note":"one calm sentence of guidance"}`;
+  const raw=await callClaude(prompt,900);
+  _aiUnlock('aiPlanDay');
+  if(!raw)return;
+  let plan;try{plan=JSON.parse((raw.match(/\{[\s\S]*\}/)||[])[0]);}catch(e){toast('Could not draft a plan — try again');return;}
+  if(!plan||!Array.isArray(plan.plan)||!plan.plan.length){toast('The plan came back empty — try again');return;}
+  _planDraft=plan;_renderPlanModal(plan);
+}
+function _renderPlanModal(plan){
+  let el=document.getElementById('plan-modal');
+  if(!el){el=document.createElement('div');el.className='mo hidden';el.id='plan-modal';el.addEventListener('click',e=>{if(e.target===el)closeM('plan-modal');});document.body.appendChild(el);}
+  const top3=new Set(plan.top3||[]);
+  const rows=plan.plan.map(p=>{
+    const t=S.tasks.find(x=>x.id===p.id);if(!t)return '';
+    const star=top3.has(p.id)?'<span style="color:var(--accent);">★</span> ':'';
+    return `<div style="display:flex;gap:12px;padding:10px 4px;border-bottom:1px solid var(--border);">
+      <span style="font-size:11.5px;font-weight:700;color:var(--accent);white-space:nowrap;min-width:74px;">${esc(p.block||'')}</span>
+      <div style="flex:1;min-width:0;"><div style="font-size:13.5px;font-weight:600;">${star}${esc(t.title)}</div>${p.why?`<div style="font-size:11.5px;color:var(--muted);margin-top:2px;">${esc(p.why)}</div>`:''}</div>
+    </div>`;
+  }).filter(Boolean).join('');
+  el.innerHTML=`<div class="md" style="width:520px;max-width:94vw;max-height:82vh;display:flex;flex-direction:column;">
+    <div class="mh"><h3>☀️ Your day</h3><button class="mc" onclick="closeM('plan-modal')">×</button></div>
+    ${plan.note?`<p style="font-size:12.5px;color:var(--muted);margin-bottom:8px;line-height:1.5;">${esc(plan.note)}</p>`:''}
+    <div style="overflow-y:auto;flex:1;margin:0 -4px;">${rows}</div>
+    <div class="mf" style="margin-top:12px;">
+      <button class="btn bg" onclick="closeM('plan-modal')">Dismiss</button>
+      <button class="btn bp" onclick="_applyPlan()">Set as my Top 3 →</button>
+    </div>
+  </div>`;
+  el.classList.remove('hidden');document.body.classList.add('modal-open');
+}
+function _applyPlan(){
+  const top3=(_planDraft&&_planDraft.top3)||[];
+  const today=new Date().toISOString().slice(0,10);
+  let n=0;
+  // clear existing Top 3 flags so the plan becomes the source of truth
+  S.tasks.forEach(t=>{if(t.isT3)t.isT3=false;});
+  top3.slice(0,3).forEach(id=>{
+    const t=S.tasks.find(x=>x.id===id);if(!t)return;
+    t.isT3=true;if(t.bucket==='inbox'||t.bucket==='backlog'||t.bucket==='someday')t.bucket='this-week';
+    if(!t.dueDate)t.dueDate=today;
+    n++;
+  });
+  save();refresh();closeM('plan-modal');_haptic(15);
+  toast(n?`☀️ ${n} task${n===1?'':'s'} set as today's Top 3`:'Plan dismissed');
 }
 
 // ── AI SEQUENCE SCORE (Eat That Frog) ─────────────────────────
@@ -9468,9 +9710,36 @@ const _SB={
   get uid(){return localStorage.getItem('taskos_sb_uid')||'';},
   get exp(){return parseInt(localStorage.getItem('taskos_sb_exp')||'0')||0;},
 };
-let _sbBusy=false,_sbApplying=false,_sbTimer=null,_sbStatus='';
+let _sbBusy=false,_sbApplying=false,_sbTimer=null,_sbStatus='',_sbPending=false;
 function _sbEnabled(){return !!(_SB.url&&_SB.anon&&_SB.refresh&&_SB.uid);}
-function _sbSetStatus(s){_sbStatus=s;_sbRenderStatus();}
+function _sbSetStatus(s){_sbStatus=s;_sbRenderStatus();_sbRenderPill();}
+// Persistent sync-status pill in the sidebar (the trust signal)
+function _sbRenderPill(){
+  const pill=document.getElementById('sync-pill'),txt=document.getElementById('sync-pill-txt');
+  if(!pill||!txt)return;
+  pill.classList.remove('ok','syncing','err','offline');
+  if(!navigator.onLine){pill.classList.add(_sbEnabled()?'offline':'');txt.textContent=_sbEnabled()?'Offline · changes saved':'Offline';return;}
+  if(!_SB.url||!_SB.anon){txt.textContent='Local only';return;}
+  if(!_sbEnabled()){txt.textContent='Sign in to sync';return;}
+  if(_sbBusy){pill.classList.add('syncing');txt.textContent='Syncing…';return;}
+  if(_sbStatus.startsWith('⚠')){pill.classList.add('err');txt.textContent='Sync error — retry';return;}
+  if(_sbPending){pill.classList.add('syncing');txt.textContent='Saving…';return;}
+  pill.classList.add('ok');
+  txt.textContent=_sbStatus&&_sbStatus.indexOf('Synced')>=0?_sbStatus.replace('Synced ⬆','Synced').replace('Synced ⬇','Synced ↓'):'Synced';
+}
+function _openSyncMenu(ev){
+  ev&&ev.stopPropagation();
+  const opts=[];
+  if(_sbEnabled())opts.push(['🔄 Sync now',"sbSyncNow(true)"]);
+  opts.push(['⬇ Download backup','exportData()']);
+  opts.push(['⬆ Restore from backup',"document.getElementById('import-file-hidden').click()"]);
+  opts.push(['☁ Sync settings','openSettings()']);
+  let el=document.getElementById('sync-menu');
+  if(!el){el=document.createElement('div');el.id='sync-menu';el.className='slash-menu';el.style.cssText='position:fixed;z-index:2000;min-width:210px;';document.body.appendChild(el);document.addEventListener('click',e=>{if(el&&!el.contains(e.target)&&e.target.id!=='sync-pill'&&!e.target.closest('#sync-pill'))el.style.display='none';});}
+  el.innerHTML=opts.map(([label,fn])=>`<div class="slash-item" onclick="event.stopPropagation();document.getElementById('sync-menu').style.display='none';${fn}"><span>${label}</span></div>`).join('');
+  const pill=document.getElementById('sync-pill').getBoundingClientRect();
+  el.style.left=Math.min(pill.left,window.innerWidth-230)+'px';el.style.top=(pill.bottom+6)+'px';el.style.display='block';
+}
 function _sbRenderStatus(){
   const el=document.getElementById('sb-status');if(!el)return;
   if(!_SB.url||!_SB.anon){el.textContent='Not configured — offline (localStorage only).';el.style.color='var(--muted)';return;}
@@ -9542,7 +9811,7 @@ async function sbPush(){
 }
 async function sbSyncNow(force){
   if(!_sbEnabled()){if(force)toast('Connect cloud sync first');return;}
-  if(_sbBusy)return;_sbBusy=true;
+  if(_sbBusy)return;_sbBusy=true;_sbRenderPill();
   try{
     const remote=await sbPull();
     const localMs=S._updatedAt||0;
@@ -9553,20 +9822,26 @@ async function sbSyncNow(force){
       save();
       _sbApplying=false;
       try{refresh();}catch(e){}
+      _sbPending=false;
       _sbSetStatus('Synced ⬇ '+new Date().toLocaleTimeString());
+      if(!force)toast('☁️ Updated from another device');
     } else {
       await sbPush();
+      _sbPending=false;
       _sbSetStatus('Synced ⬆ '+new Date().toLocaleTimeString());
     }
-  }catch(e){_sbSetStatus('⚠ '+e.message);}
-  finally{_sbBusy=false;}
+  }catch(e){_sbPending=true;_sbSetStatus('⚠ '+e.message);}
+  finally{_sbBusy=false;_sbRenderPill();}
 }
 function _sbScheduleSync(){
   if(!_sbEnabled()||_sbApplying)return;
+  _sbPending=true;_sbRenderPill();
+  if(!navigator.onLine)return; // stay queued; flushes on 'online'
   clearTimeout(_sbTimer);
   _sbTimer=setTimeout(()=>{
     if(!_sbEnabled())return;
-    sbPush().then(()=>_sbSetStatus('Synced ⬆ '+new Date().toLocaleTimeString())).catch(e=>_sbSetStatus('⚠ '+e.message));
+    if(!navigator.onLine){_sbRenderPill();return;}
+    sbPush().then(()=>{_sbPending=false;_sbSetStatus('Synced ⬆ '+new Date().toLocaleTimeString());}).catch(e=>{_sbPending=true;_sbSetStatus('⚠ '+e.message);});
   },2500);
 }
 // Auto-snapshot: capture a daily Givelink history point so the Pace Engine
@@ -9603,7 +9878,21 @@ function toggleSB(){
 // ── INIT ──────────────────────────────────────────────────────
 load();seed();seedGoals();resetRecurring();_genDailyQuests();_maybeShowWeeklyWrapped();_initSidebarSwipe();_autoSnapshot();
 setTimeout(()=>{if(_sbEnabled())sbSyncNow();},900);
-try{const _nc=JSON.parse(localStorage.getItem('taskos_nav_collapsed')||'{}');document.querySelectorAll('.ns-group').forEach(g=>{const collapsed=_nc[g.dataset.ns]??g.classList.contains('collapsed');if(collapsed)g.classList.add('collapsed');else g.classList.remove('collapsed');const arr=g.querySelector('.ns-arrow');if(arr)arr.textContent=collapsed?'▸':'▾';});}catch(e){}
+try{
+  const _raw=localStorage.getItem('taskos_nav_collapsed');
+  const _nc=JSON.parse(_raw||'{}');
+  const _firstRun=_raw===null; // calm-by-default: collapse everything except Pinned + Main on first run
+  const _keepOpen={pinned:1,views:1,main:1};
+  document.querySelectorAll('.ns-group').forEach(g=>{
+    const ns=g.dataset.ns;
+    let collapsed;
+    if(ns in _nc)collapsed=_nc[ns];
+    else if(_firstRun)collapsed=!_keepOpen[ns];
+    else collapsed=g.classList.contains('collapsed');
+    g.classList.toggle('collapsed',!!collapsed);
+    const arr=g.querySelector('.ns-arrow');if(arr)arr.textContent=collapsed?'▸':'▾';
+  });
+}catch(e){}
 document.title='Task OS — '+profileName;
 const _lastP=localStorage.getItem('taskos_lastview');
 if(_lastP&&_lastP!=='dashboard'){nav(_lastP);}else{renderDash();}
@@ -11505,9 +11794,10 @@ function confirmPasteImport(){
 function closeModal(id){document.getElementById(id)?.classList.add('hidden');}
 
 // ── OFFLINE INDICATOR ─────────────────────────────────────────
-window.addEventListener('online',()=>{const p=document.getElementById('offline-pill');if(p)p.style.display='none';});
-window.addEventListener('offline',()=>{const p=document.getElementById('offline-pill');if(p)p.style.display='';});
+window.addEventListener('online',()=>{const p=document.getElementById('offline-pill');if(p)p.style.display='none';_sbRenderPill();if(_sbEnabled()&&_sbPending)sbSyncNow();});
+window.addEventListener('offline',()=>{const p=document.getElementById('offline-pill');if(p)p.style.display='';_sbRenderPill();});
 if(!navigator.onLine){const p=document.getElementById('offline-pill');if(p)p.style.display='';}
+try{_sbRenderPill();}catch(e){}
 
 // ── CONTENT PIPELINE ──────────────────────────────────────────
 function renderContent(){
@@ -12685,7 +12975,7 @@ initChecklists();
 _initPullRefresh();
 _initSheetDismiss();
 _maybeOnboard();
-try{_renderSavedViews();_updateUnreadBadges();}catch(e){}
+try{_renderSavedViews();_updateUnreadBadges();_addPinStars();_renderPinnedViews();}catch(e){}
 // Fade out the launch splash once the app has painted (with a safety fallback)
 (function(){
   function _hideSplash(){const s=document.getElementById('app-splash');if(s&&!s.classList.contains('hide')){s.classList.add('hide');setTimeout(()=>s.remove(),500);}}

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -44,6 +44,12 @@ create policy "app_state update own"
 --      paste the URL + anon key, enter an email + password, click "Connect & Sync".
 --    The first connect signs up/in and creates your row; data then syncs across devices.
 --
+-- To let OTHERS sign up (hosted product mode) instead of pasting keys:
+--  • Authentication → Providers → enable Email and Google.
+--  • Authentication → URL Configuration → add your site URL to the redirect allow-list.
+--  • Paste the Project URL + anon key into APP_CONFIG at the top of index.html's
+--    script. Users then get the Sign up / Log in screen — no key pasting.
+--
 -- Notes:
 --  • The anon key is meant to be public; Row Level Security above ensures a user
 --    can only ever touch their own row.

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260707';
+const CACHE = 'task-os-20260708';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260705';
+const CACHE = 'task-os-20260706';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260706';
+const CACHE = 'task-os-20260707';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260708';
+const CACHE = 'task-os-20260709';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.anthropic.com https://hooks.slack.com https://ntfy.sh https://readwise.io https://api.notion.com https://*.supabase.co wss://*.supabase.co; font-src 'self'; frame-ancestors 'none';" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.anthropic.com https://hooks.slack.com https://ntfy.sh https://readwise.io https://api.notion.com https://*.supabase.co wss://*.supabase.co https://us.i.posthog.com https://us-assets.i.posthog.com; font-src 'self'; frame-ancestors 'none';" }
       ]
     },
     {


### PR DESCRIPTION
Ships the full Superhuman/Notion/Oura-inspired upgrade plus the foundation to let others sign up.

## Mobile-native pass
- Bottom-sheet task drawer on mobile (grabber, swipe-down dismiss, list peeks behind); right-slide panel on desktop.
- Bottom tab bar: Today · Inbox · center **+** · Goals · Search, with an unread count; retired the redundant floating FAB.
- Board & Calendar views in All Tasks (List/Board/Calendar segmented control); board = life-area columns with scroll-snap, calendar = month grid.
- Unread/read state (bold + accent dot, clears on open), checkbox pop, j/k + swipe-through inside the drawer.

## Power features
- Slash menu in Quick Add (`/today`, `/tomorrow`, life-areas).
- AI auto-triage of the inbox and **Plan my day** (AI time-blocked today → sets Top 3).
- Natural-language ⌘K (`snooze X tomorrow`, `X due friday`, plus an "Ask AI" interpret path).
- Saved views pinned to the sidebar; snooze nudges (in 3 days / 1 week); `.ics` calendar export.

## Trust, focus, performance
- Sync-status pill + offline write-queue + one-tap backup/restore; "updated from another device" surfacing.
- Calm sidebar: Pinned section, live filter, non-essential groups collapsed by default.
- All Tasks list windowed (60-row initial render + infinite scroll) so hundreds of tasks don't all hit the DOM.

## Go-live foundation (A/B/D)
- **Hosted auth** gated behind `APP_CONFIG` (now wired to a live Supabase project): email + password, magic-link, Google OAuth; auth gate doubles as a positioning hero. Optional serverless Claude proxy (`api/claude.js`) so users don't need their own key.
- **PostHog analytics** (no-ops until a key is set) with activation-funnel events.

Verified on desktop + mobile with headless Chromium across all 22 views: no horizontal scroll, every feature exercised green, and the empty-config path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_