### PR TITLE
Fix: new signups must not inherit the owner's seeded data

### DIFF
--- a/index.html
+++ b/index.html
@@ -9313,6 +9313,7 @@ function _onbRender(){
 function _onbNext(){if(_onbIdx<_ONB.length-1){_onbIdx++;_onbRender();}else _onbFinish();}
 function _onbFinish(){localStorage.setItem('taskos_onboarded','1');document.getElementById('onboarding-modal').classList.add('hidden');document.body.classList.remove('modal-open');}
 function _maybeOnboard(){
+  if(_hostedMode())return; // hosted accounts get the welcome-task starter instead of the modal
   if(localStorage.getItem('taskos_onboarded'))return;
   // Existing users (already have data) shouldn't be interrupted
   if((S.tasks&&S.tasks.length>3)||(S.xp||0)>0){localStorage.setItem('taskos_onboarded','1');return;}
@@ -10022,12 +10023,32 @@ async function sbSyncNow(force){
       _sbSetStatus('Synced ⬇ '+new Date().toLocaleTimeString());
       if(!force)toast('☁️ Updated from another device');
     } else {
+      // Brand-new hosted account with nothing in the cloud yet → friendly starter, not empty.
+      if(_hostedMode()&&!remote&&!S._welcomed&&(!S.tasks||S.tasks.length===0)){_welcomeSeed();}
       await sbPush();
       _sbPending=false;
       _sbSetStatus('Synced ⬆ '+new Date().toLocaleTimeString());
     }
   }catch(e){_sbPending=true;_sbSetStatus('⚠ '+e.message);}
   finally{_sbBusy=false;_sbRenderPill();}
+}
+// A small, generic starter set so a new account feels intentional (never the owner's data).
+function _welcomeSeed(){
+  S._welcomed=true;
+  // Personalize the greeting from the sign-in email (so it's never "Panos")
+  if(!localStorage.getItem('taskos_name')&&_SB.email){
+    const nm=_SB.email.split('@')[0].replace(/[._-]+/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
+    if(nm){profileName=nm;localStorage.setItem('taskos_name',nm);}
+  }
+  const mk=(title,bucket)=>({id:uid(),title,notes:'',bucket,category:'other',urgency:'low',importance:'high',energy:'high',depth:'medium',status:'todo',isT3:false,t3s:null,timeBlock:null,dueDate:'',goalId:null,recurring:'',checklist:[],blockedBy:[],linkedPeople:[],ifThen:'',bundledWith:'',read:false,createdAt:new Date().toISOString(),completedAt:null});
+  S.tasks.push(
+    mk('👋 Welcome! Tap a task to open it — swipe left to complete','inbox'),
+    mk('Press ⌘K (or the search icon) to command anything','inbox'),
+    mk('Capture a few things you need to do','inbox'),
+    mk('Try “Plan my day” on the dashboard','this-week'),
+    mk('Set a goal in Goals, then link tasks to it','this-week')
+  );
+  save();try{refresh();}catch(e){}
 }
 function _sbScheduleSync(){
   if(!_sbEnabled()||_sbApplying)return;
@@ -10072,7 +10093,12 @@ function toggleSB(){
 }
 
 // ── INIT ──────────────────────────────────────────────────────
-load();seed();seedGoals();resetRecurring();_genDailyQuests();_maybeShowWeeklyWrapped();_initSidebarSwipe();_autoSnapshot();
+load();
+// In hosted (multi-user) mode we must NOT seed the owner's personal demo data —
+// new accounts start clean and get a small welcome starter after they sign in;
+// the owner's own data arrives from their synced cloud row on login.
+if(!_hostedMode()){seed();seedGoals();}
+resetRecurring();_genDailyQuests();_maybeShowWeeklyWrapped();_initSidebarSwipe();_autoSnapshot();
 setTimeout(()=>{if(_sbEnabled())sbSyncNow();},900);
 try{
   const _raw=localStorage.getItem('taskos_nav_collapsed');

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260709';
+const CACHE = 'task-os-20260710';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',


### PR DESCRIPTION
In hosted mode the app seeded the owner's personal demo tasks + goals into every fresh browser, which then synced to each new account — so anyone signing up saw ~389 of the owner's tasks.

- Skip `seed()` / `seedGoals()` when a backend is configured; the owner's own data comes from their synced cloud row on login.
- New accounts (empty cloud row) get a small generic welcome starter (5 example tasks) and a greeting personalized from their sign-in email.
- Skip the legacy onboarding modal in hosted mode.

Local / bring-your-own mode is unchanged (verified: 389 tasks seed, no gate). Hosted mode verified: 0 personal tasks at boot, welcome starter adds 5, greeting reads from email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_