### PR TITLE
Make logout clean and safe for re-login

### DIFF
--- a/index.html
+++ b/index.html
@@ -9964,10 +9964,17 @@ function authGoogle(){
   location.href=`${_SB.url}/auth/v1/authorize?provider=google&redirect_to=${redirect}`;
 }
 function authLogout(){
-  ['access','refresh','exp','uid'].forEach(k=>localStorage.removeItem('taskos_sb_'+k));
   track('auth_logout',{});
   try{if(window.posthog&&posthog.reset)posthog.reset();}catch(e){}
-  if(_hostedMode())location.reload();else toast('Signed out (local data kept)');
+  ['access','refresh','exp','uid','email'].forEach(k=>localStorage.removeItem('taskos_sb_'+k));
+  if(_hostedMode()){
+    // Clear this account's local cache so the next login starts from THEIR cloud data,
+    // never the previous account's (safe: hosted data lives in the synced cloud row).
+    try{localStorage.removeItem('taskos');localStorage.removeItem('taskos_name');}catch(e){}
+    location.replace(location.origin+location.pathname); // clean URL + fresh boot → shows the gate
+  } else {
+    toast('Signed out (local data kept)');
+  }
 }
 async function _afterAuth(){
   _hideAuthGate();

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260711';
+const CACHE = 'task-os-20260712';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',


### PR DESCRIPTION
Sign out now clears the local app cache (not just the session token), so the next person to log in on the same browser starts from their own cloud data — never the previous account's — and can't accidentally sync it into their row. Safe because hosted data lives in the synced cloud row. Returns to a clean gate for immediate re-login.

Verified headless: after logout the previous account's tasks are wiped (0 tasks, no leaked data) and the gate reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_