### PR TITLE
Land on Today after login (not a stale last view)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9980,7 +9980,7 @@ async function _afterAuth(){
   _hideAuthGate();
   _phIdentify();
   try{await sbSyncNow(true);}catch(e){}
-  try{refresh();}catch(e){}
+  try{nav('dashboard');}catch(e){try{refresh();}catch(_){}} // always land on Today after login, not a stale last view
   _sbRenderPill();_renderAccountChip();
   toast('👋 Welcome to Task OS');
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260712';
+const CACHE = 'task-os-20260713';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',


### PR DESCRIPTION
After signing in, always navigate to the dashboard instead of reopening whatever view was last active (e.g. Givelink OS) — which was showing a stale screen on fresh mobile logins.

Verified: from a stale `givelink-dash` view, `_afterAuth()` lands on `v-dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_