### PR TITLE
Product-led growth: referral links + share-the-win moments + marketing kit

### DIFF
--- a/MARKETING.md
+++ b/MARKETING.md
@@ -1,0 +1,76 @@
+# Task OS — Marketing & Growth Kit
+
+Everything you need to get people using Task OS. Honest, founder-voice, no fabricated metrics.
+
+Production URL: `https://task-management-beige-eight.vercel.app/`
+
+---
+
+## Built-in product-led growth (already shipped)
+
+These make the app spread on its own — use them, and watch the events in PostHog.
+
+| Mechanic | Where | Event |
+|---|---|---|
+| **Referral-attributed invite** | Account menu → "Invite a friend" | `share` (ctx: invite) |
+| **Referral capture on arrival** | any `?ref=<uid>` link | `referred_arrival`, then `signup` carries `ref` |
+| **Share-the-win** | Inbox Zero card, all-quests-complete toast | `share` (ctx: inbox_zero / quests) |
+| **Rich link previews** | Open Graph / Twitter meta + `og-image.png` | — |
+| **First-run onboarding tour** | fires on a new account's first login | `onboarding_started` / `_completed` |
+
+**Attribution loop:** every invite/win link is `...?ref=<the sharer's user id>`. New arrivals store that ref and it rides along on their `signup` event, so you can see who drives signups (and later reward them).
+
+---
+
+## The 30-day launch sequence
+
+1. **Week 0 — soft launch.** Post to your own X/LinkedIn, DM ~20 friends. Get your first 10 real users, fix what breaks.
+2. **Week 1 — build in public.** 3–4 posts/week: a screenshot, a feature, a lesson. Warms an audience before the big launch.
+3. **Week 2 — communities.** r/productivity, r/Notion, r/getdisciplined, Indie Hackers. Lead with the *problem you solved for yourself*.
+4. **Week 3 — Product Hunt + Show HN.** Tue–Thu. Rally your Week-1 audience to comment early.
+5. **Ongoing — content/SEO.** "Superhuman shortcuts for tasks", "Wheel of Life + Oura rings", templates. Use Ahrefs/Semrush for keywords.
+
+---
+
+## Ready-to-post copy
+
+### X / Twitter launch thread (hook)
+> I got tired of my to-do app being a graveyard. So I rebuilt my personal OS from scratch — Superhuman-fast, Notion-deep, with AI that plans my day.
+>
+> It's live and free. Here's what it does 🧵 → https://task-management-beige-eight.vercel.app/
+
+Follow with one tweet + screenshot per feature: ⌘K capture · swipe-to-done · Plan-my-day AI · goals↔tasks · Oura rings.
+
+### Product Hunt
+**Tagline (60 char):** Task OS — the calm, keyboard-fast home for everything you do
+
+**First comment:**
+> Hey PH 👋 I built Task OS because every to-do app I tried was either too shallow (a flat list) or too heavy (a Notion I stopped maintaining). This is the middle: Superhuman speed for tasks, Notion depth for goals/habits/reviews, and AI that triages your inbox and plans your day. Free to start, syncs everywhere, works offline. Would love feedback on what's missing.
+
+### Reddit (r/productivity)
+> **I rebuilt my task app around one rule: it has to be faster than my brain.**
+> Everything is ⌘K. You reply to a task in plain English to change it ("snooze till Friday"). One tap AI-triages your whole inbox. And every task can point at a goal so the list never feels pointless. Built it for myself, opened it up — [link]. What would you add?
+
+### LinkedIn
+> For 2 years my tasks lived in 4 different apps and none of them stuck. So I built the one I actually wanted: calm, keyboard-fast, and smart enough to plan my day for me. It's live and free — [link]. Feedback welcome.
+
+### Show HN
+> Show HN: Task OS – a keyboard-fast personal OS (tasks + goals + habits + AI)
+> Single-page PWA, offline-first, Supabase sync. AI (via Claude) triages your inbox and drafts a time-blocked day. Built it for myself; it's free. Happy to answer anything technical.
+
+---
+
+## Measure it (PostHog)
+
+Activation funnel: `signup` → `task_created` (×5) → return on day 2.
+- Drop before 5 tasks → the onboarding/first-capture needs work.
+- Drop before D2 → the reminder/notification game needs work.
+
+Growth funnel: `share` → `referred_arrival` → `signup (ref set)`. Watch the ratio; double down on whichever share moment (invite vs inbox_zero) converts best.
+
+---
+
+## Before you promote widely
+- **Upgrade Supabase to Pro** so the project never auto-pauses (a paused backend = everyone locked out).
+- Confirm **Site URL** + redirect allow-list point at production.
+- Optionally deploy the **`/api/claude` proxy** so users get AI without their own key.

--- a/index.html
+++ b/index.html
@@ -4307,7 +4307,7 @@ function renderProcCard(){
   const inbox=active().filter(t=>t.bucket==='inbox');
   const pa=document.getElementById('proc-area');
   if(!inbox.length){
-    pa.innerHTML=`<div class="proc-done"><div class="pd-check">✓</div><div class="pd-title">Inbox Zero</div><div class="pd-sub">Every thought has a home. Nice work.</div><button class="btn bp sm" onclick="toggleProc()" style="margin-top:18px;">Done</button></div>`;
+    pa.innerHTML=`<div class="proc-done"><div class="pd-check">✓</div><div class="pd-title">Inbox Zero</div><div class="pd-sub">Every thought has a home. Nice work.</div><div style="display:flex;gap:8px;justify-content:center;margin-top:18px;flex-wrap:wrap;"><button class="btn bp sm" onclick="shareWin('inbox_zero')">🎉 Share the win</button><button class="btn bg sm" onclick="toggleProc()">Done</button></div></div>`;
     if(!window._procCelebrated){window._procCelebrated=true;try{_fireConfetti('deep');}catch(e){}}
     return;
   }
@@ -7701,7 +7701,7 @@ function _checkQuestCompletion(){
   if(newlyDone&&S.dailyQuests.every(q=>q.done)&&S._allQuestsBonusDate!==today){
     S._allQuestsBonusDate=today;
     save();
-    setTimeout(()=>{toast('🎉 All quests complete! +50 XP bonus',4000);awardXP(50,'all quests complete');_fireConfetti('deep');},400);
+    setTimeout(()=>{toast('🎉 All quests complete! +50 XP · <span style="cursor:pointer;font-weight:700;color:var(--accent);" onclick="shareWin(\'quests\')">Share the win</span>',5000);awardXP(50,'all quests complete');_fireConfetti('deep');},400);
   }
 }
 
@@ -10034,16 +10034,36 @@ function _openAcctMenu(ev){
   el.style.top=Math.max(8,r.top-h-6)+'px';
 }
 // Invite-a-friend growth loop: native share sheet on mobile, copy-link fallback elsewhere.
-async function shareInvite(){
-  const url='https://task-management-beige-eight.vercel.app/';
-  const text='I run my whole life in Task OS — calm, keyboard-fast, and the AI plans my day. Try it (free):';
-  track('invite_shared',{});
+const _APP_URL='https://task-management-beige-eight.vercel.app/';
+// Referral-attributed link: carries who invited them so growth is measurable.
+function _refUrl(){const r=(_SB&&_SB.uid)?('?ref='+encodeURIComponent(_SB.uid)):'';return _APP_URL+r;}
+// One share primitive: native sheet on mobile, copy-link fallback elsewhere.
+async function _share(text,ev){
+  const url=_refUrl();track('share',{ctx:ev||'invite'});
   if(navigator.share){
     try{await navigator.share({title:'Task OS',text,url});return;}
     catch(e){if(e&&e.name==='AbortError')return;}
   }
-  try{await navigator.clipboard.writeText(text+' '+url);toast('🔗 Invite copied — paste it anywhere');}
-  catch(e){window.prompt('Share this link with a friend:',url);}
+  try{await navigator.clipboard.writeText(text+' '+url);toast('🔗 Copied — paste it anywhere');}
+  catch(e){window.prompt('Share this link:',url);}
+}
+function shareInvite(){return _share('I run my whole life in Task OS — calm, keyboard-fast, and the AI plans my day. Try it (free):','invite');}
+// Capture a ?ref=<uid> on arrival so we can attribute (and later reward) invites.
+function _captureRef(){
+  try{
+    const u=new URL(location.href);const ref=u.searchParams.get('ref');
+    if(ref){localStorage.setItem('taskos_ref',ref);track('referred_arrival',{ref});
+      u.searchParams.delete('ref');history.replaceState(null,'',u.pathname+(u.search||'')+(u.hash||''));}
+  }catch(e){}
+}
+// Share a delight moment (Inbox Zero, cleared Top 3, etc.) — turns wins into distribution.
+function shareWin(context){
+  const lines={
+    inbox_zero:'Just hit Inbox Zero 📥→0 in Task OS. Everything captured, everything has a home. Try it (free):',
+    top3:'Cleared my Top 3 for the day ✅✅✅ in Task OS. Calm, keyboard-fast, and the AI plans my day. Try it:',
+    quests:'Finished all my daily quests in Task OS 🎯 — the calmest to-do app I’ve used. Try it (free):'
+  };
+  return _share(lines[context]||lines.inbox_zero,context);
 }
 function _acctRename(){
   showPrompt('Your name',n=>{
@@ -10128,6 +10148,7 @@ async function sbSyncNow(force){
 // A small, generic starter set so a new account feels intentional (never the owner's data).
 function _welcomeSeed(){
   S._welcomed=true;window._justWelcomed=true; // triggers the onboarding tour after this login
+  try{track('signup',{ref:localStorage.getItem('taskos_ref')||''});}catch(e){}
   // Personalize the greeting from the sign-in email (so it's never "Panos")
   if(!localStorage.getItem('taskos_name')&&_SB.email){
     const nm=_SB.email.split('@')[0].replace(/[._-]+/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
@@ -13288,6 +13309,7 @@ _initSheetDismiss();
 _maybeOnboard();
 try{_renderSavedViews();_updateUnreadBadges();_addPinStars();_renderPinnedViews();}catch(e){}
 try{_initPostHog();}catch(e){}
+try{_captureRef();}catch(e){}
 try{_authBoot();}catch(e){}
 try{_renderAccountChip();}catch(e){}
 // Fade out the launch splash once the app has painted (with a safety fallback)

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'task-os-20260716';
+const CACHE = 'task-os-20260717';
 const STATIC = [
   './manifest.json',
   './manifest-givelink.json',


### PR DESCRIPTION
Make the app itself spread:

- **Referral attribution** — invite/share links carry `?ref=<sharer uid>`; arrivals capture it (`referred_arrival`) and it rides along on their `signup` event, so growth is measurable and rewardable. URL is cleaned after capture.
- **Share-the-win** — one-tap "Share the win" at high-delight moments (Inbox Zero card, all-quests-complete toast) with contextual copy.
- Unified `_share()` primitive (native sheet on mobile, copy-link fallback).
- **MARKETING.md** — launch sequence + ready-to-post copy (X, PH, Reddit, LinkedIn, Show HN) + the PLG/activation events to watch in PostHog.

Verified: ref captured on arrival + URL cleaned, share links carry the ref, contextual win copy, events fire. Parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_