### PR TITLE
Brand consistency: rebrand update banner + purge stray old-brand colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#8b7cff">
+<meta name="theme-color" content="#0a0a0f">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="Arete">
@@ -36,9 +36,9 @@
 /* ── LAUNCH SPLASH ─────────────────────────────────────────────── */
 #app-splash{position:fixed;inset:0;z-index:99999;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;background:#0a0a0f;transition:opacity .45s ease;}
 #app-splash.hide{opacity:0;pointer-events:none;}
-#app-splash .sl-mark{animation:splashPulse 1.6s ease-in-out infinite;filter:drop-shadow(0 0 22px rgba(139,124,255,.35));}
+#app-splash .sl-mark{animation:splashPulse 1.6s ease-in-out infinite;filter:drop-shadow(0 0 22px rgba(90,73,224,.35));}
 #app-splash .sl-name{font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:18px;font-weight:800;letter-spacing:-.4px;color:#ecedf3;}
-#app-splash .sl-name span{background:linear-gradient(135deg,#8b7cff,#c08cff);-webkit-background-clip:text;background-clip:text;color:transparent;}
+#app-splash .sl-name span{background:linear-gradient(135deg,#5a49e0,#8b5ce6);-webkit-background-clip:text;background-clip:text;color:transparent;}
 @keyframes splashPulse{0%,100%{transform:scale(1);opacity:1;}50%{transform:scale(1.06);opacity:.82;}}
 @media(prefers-reduced-motion:reduce){#app-splash .sl-mark{animation:none;}}
 :root{
@@ -60,7 +60,7 @@ body.light{
 body.light{background:radial-gradient(1000px 560px at 84% -14%,rgba(90,73,224,.055),transparent 58%),radial-gradient(760px 520px at 4% 114%,rgba(14,145,168,.035),transparent 55%),var(--bg);background-attachment:fixed;}
 body.light .bp{color:#fff;}
 body.light .bni.active{color:var(--accent);}
-body{font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:radial-gradient(1100px 620px at 82% -12%,rgba(139,124,255,.10),transparent 60%),radial-gradient(820px 560px at 6% 112%,rgba(95,211,230,.055),transparent 55%),var(--bg);background-attachment:fixed;color:var(--text);display:flex;height:100vh;overflow:hidden;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;letter-spacing:-.006em;}
+body{font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:radial-gradient(1100px 620px at 82% -12%,rgba(90,73,224,.10),transparent 60%),radial-gradient(820px 560px at 6% 112%,rgba(95,211,230,.055),transparent 55%),var(--bg);background-attachment:fixed;color:var(--text);display:flex;height:100vh;overflow:hidden;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;letter-spacing:-.006em;}
 /* SIDEBAR */
 .sidebar{width:210px;background:var(--surface);border-right:1px solid var(--border);display:flex;flex-direction:column;padding:16px 0;flex-shrink:0;overflow-y:auto;}
 .logo{display:flex;align-items:center;gap:9px;padding:0 16px 16px;border-bottom:1px solid var(--border);margin-bottom:8px;}
@@ -180,7 +180,7 @@ hr{border:none;border-top:1px solid var(--border);margin:18px 0;}
 .co{background:rgba(134,142,150,.15);color:var(--co);}
 /* BUTTONS */
 .btn{padding:9px 16px;border-radius:9px;border:none;cursor:pointer;font-size:13px;font-weight:600;transition:all .12s;display:inline-flex;align-items:center;gap:5px;white-space:nowrap;}
-.bp{background:var(--brand-gradient);color:#fff;box-shadow:0 4px 16px -4px rgba(139,124,255,.5);}.bp:hover{filter:brightness(1.07);box-shadow:0 6px 22px -4px rgba(139,124,255,.6);}
+.bp{background:var(--brand-gradient);color:#fff;box-shadow:0 4px 16px -4px rgba(90,73,224,.5);}.bp:hover{filter:brightness(1.07);box-shadow:0 6px 22px -4px rgba(90,73,224,.6);}
 .btn:active{transform:scale(.96);}
 .bg{background:transparent;color:var(--muted);border:1px solid var(--border);}.bg:hover{background:var(--surface2);color:var(--text);}
 .bd{background:rgba(255,107,107,.12);color:var(--q1);border:1px solid rgba(255,107,107,.25);}.bd:hover{background:rgba(255,107,107,.22);}
@@ -253,7 +253,7 @@ select.fc option{background:var(--surface2);}
 .fp{padding:3px 10px;border-radius:16px;font-size:11px;cursor:pointer;border:1px solid var(--border);color:var(--muted);background:transparent;transition:all .12s;}
 .fp:hover,.fp.active{background:var(--surface2);color:var(--text);border-color:var(--accent);}
 /* FAB */
-.fab{position:fixed;bottom:24px;right:24px;width:52px;height:52px;background:var(--brand-gradient);border:none;border-radius:50%;color:#fff;font-size:24px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 6px 20px rgba(124,108,255,.45);transition:transform .18s cubic-bezier(.34,1.56,.64,1);z-index:100;}
+.fab{position:fixed;bottom:24px;right:24px;width:52px;height:52px;background:var(--brand-gradient);border:none;border-radius:50%;color:#fff;font-size:24px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 6px 20px rgba(90,73,224,.45);transition:transform .18s cubic-bezier(.34,1.56,.64,1);z-index:100;}
 .fab.open{transform:rotate(45deg);}
 #fab-dial{position:fixed;right:26px;bottom:88px;z-index:101;display:flex;flex-direction:column;align-items:flex-end;gap:10px;}
 #fab-dial.hidden{display:none;}
@@ -277,7 +277,7 @@ select.fc option{background:var(--surface2);}
 .app-lnk:hover{background:var(--surface2);color:var(--text);}
 @media(max-width:768px){body{flex-direction:column;}.mob-bar{display:flex;}.main{padding:14px;}.fr{grid-template-columns:1fr;}.goal-dash{grid-template-columns:1fr 1fr;}}
 .cmdk{position:fixed;inset:0;background:rgba(6,6,10,.6);display:flex;align-items:flex-start;justify-content:center;padding-top:12vh;z-index:2000;backdrop-filter:blur(8px) saturate(120%);}.cmdk.hidden{display:none;}
-.cmdk-box{background:var(--surface);border:1px solid var(--border);border-radius:16px;width:580px;max-width:94vw;box-shadow:0 28px 90px -12px rgba(0,0,0,.6),0 0 0 1px var(--border),0 0 70px -20px rgba(139,124,255,.4);overflow:hidden;}
+.cmdk-box{background:var(--surface);border:1px solid var(--border);border-radius:16px;width:580px;max-width:94vw;box-shadow:0 28px 90px -12px rgba(0,0,0,.6),0 0 0 1px var(--border),0 0 70px -20px rgba(90,73,224,.4);overflow:hidden;}
 .cmdk-ir{display:flex;align-items:center;gap:10px;padding:8px 16px;border-bottom:1px solid var(--border);}
 .cmdk-i{flex:1;background:none;border:none;padding:12px 0;color:var(--text);font-size:16px;outline:none;letter-spacing:-.01em;}
 .cmdk-opts{display:flex;gap:6px;padding:9px 14px;border-bottom:1px solid var(--border);flex-wrap:wrap;}
@@ -521,7 +521,7 @@ body.theme-anim,body.theme-anim *{transition:background-color .35s ease,color .3
 /* ── EMPTY STATE ILLUSTRATION ────────────────────────────────── */
 .empty-illus{width:64px;height:64px;border-radius:50%;background:var(--surface2);display:flex;align-items:center;justify-content:center;font-size:30px;margin:0 auto 12px;border:1px solid var(--border);}
 /* ── ONBOARDING ──────────────────────────────────────────────── */
-#onb-illus{width:84px;height:84px;border-radius:24px;background:var(--brand-gradient);display:flex;align-items:center;justify-content:center;font-size:42px;margin:0 auto 16px;box-shadow:0 8px 28px rgba(124,108,255,.4);}
+#onb-illus{width:84px;height:84px;border-radius:24px;background:var(--brand-gradient);display:flex;align-items:center;justify-content:center;font-size:42px;margin:0 auto 16px;box-shadow:0 8px 28px rgba(90,73,224,.4);}
 /* ── REDUCED MOTION ──────────────────────────────────────────── */
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.001ms!important;animation-iteration-count:1!important;transition-duration:.001ms!important;scroll-behavior:auto!important;}}
 /* ── BULK BAR ────────────────────────────────────────────────── */
@@ -785,7 +785,7 @@ body.light .seg-btn.active{background:#fff;}
 .acct-menu-item.danger{color:#ef4444;}
 /* ── AUTH GATE + HERO ───────────────────────────────────────────── */
 body.auth-locked{overflow:hidden;}
-.auth-gate{position:fixed;inset:0;z-index:100000;display:flex;align-items:center;justify-content:center;gap:56px;padding:40px 28px;background:radial-gradient(1200px 600px at 20% -10%,rgba(139,124,255,.16),transparent 60%),var(--bg);overflow-y:auto;flex-wrap:wrap;}
+.auth-gate{position:fixed;inset:0;z-index:100000;display:flex;align-items:center;justify-content:center;gap:56px;padding:40px 28px;background:radial-gradient(1200px 600px at 20% -10%,rgba(90,73,224,.16),transparent 60%),var(--bg);overflow-y:auto;flex-wrap:wrap;}
 .ag-hero-col{max-width:460px;flex:1 1 360px;min-width:0;}
 .ag-brand{display:flex;align-items:center;gap:10px;margin-bottom:26px;}
 .ag-word{font-size:20px;font-weight:800;letter-spacing:-.3px;}
@@ -2547,7 +2547,7 @@ function fillBlockerDrop(currentId,selectedIds=[]){
 function applyTheme(light){
   document.body.classList.toggle('light',light);
   const mc=document.querySelector('meta[name="theme-color"]');
-  if(mc)mc.content=light?'#f5f5f0':'#58a6ff';
+  if(mc)mc.content=light?'#f7f6f3':'#0a0a0f';
   const sb=document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]');
   if(sb)sb.content=light?'default':'black-translucent';
   const btn=document.getElementById('theme-toggle-btn');
@@ -9150,7 +9150,7 @@ function _initSwipe(el,id){
     const dx=e.touches[0].clientX-startX;
     const dy=Math.abs(e.touches[0].clientY-startY);
     if(dy>30)return;
-    if(Math.abs(dx)>10){moved=true;el.style.transform=`translateX(${Math.min(72,Math.max(-72,dx))}px)`;el.style.background=dx<-20?'rgba(126,224,160,.20)':dx>20?'rgba(139,124,255,.18)':'';el.setAttribute('data-swipe',dx<-40?'done':dx>40?'snooze':'');}
+    if(Math.abs(dx)>10){moved=true;el.style.transform=`translateX(${Math.min(72,Math.max(-72,dx))}px)`;el.style.background=dx<-20?'rgba(126,224,160,.20)':dx>20?'rgba(90,73,224,.18)':'';el.setAttribute('data-swipe',dx<-40?'done':dx>40?'snooze':'');}
   },{passive:true});
   el.addEventListener('touchend',e=>{
     const dx=e.changedTouches[0].clientX-startX;
@@ -10205,10 +10205,10 @@ function _drawStatsCard(){
   const W=1080,H=1350,c=document.createElement('canvas');c.width=W;c.height=H;const x=c.getContext('2d');
   const s=_shareStats();
   x.fillStyle='#0a0a0f';x.fillRect(0,0,W,H);
-  let g=x.createRadialGradient(240,120,0,240,120,1000);g.addColorStop(0,'rgba(139,124,255,.38)');g.addColorStop(.6,'rgba(139,124,255,0)');x.fillStyle=g;x.fillRect(0,0,W,H);
+  let g=x.createRadialGradient(240,120,0,240,120,1000);g.addColorStop(0,'rgba(90,73,224,.38)');g.addColorStop(.6,'rgba(90,73,224,0)');x.fillStyle=g;x.fillRect(0,0,W,H);
   g=x.createRadialGradient(W,H,0,W,H,760);g.addColorStop(0,'rgba(182,129,245,.22)');g.addColorStop(.6,'rgba(182,129,245,0)');x.fillStyle=g;x.fillRect(0,0,W,H);
   // logo mark
-  x.save();x.translate(96,96);x.strokeStyle='#8b7cff';x.lineWidth=7;x.lineCap='round';x.lineJoin='round';
+  x.save();x.translate(96,96);x.strokeStyle='#5a49e0';x.lineWidth=7;x.lineCap='round';x.lineJoin='round';
   x.beginPath();x.arc(28,28,24,0,Math.PI*2);x.stroke();
   x.beginPath();x.moveTo(17,29);x.lineTo(25,37);x.lineTo(40,20);x.stroke();x.restore();
   x.fillStyle='#fff';x.font='800 46px Inter, sans-serif';x.textBaseline='middle';x.fillText('Task',170,124);
@@ -14014,10 +14014,10 @@ try{_renderAccountChip();}catch(e){}
 <div class="mo hidden" id="modal-overlay"><div class="md"></div></div>
 
 <!-- UPDATE BANNER -->
-<div id="update-banner" style="display:none;position:fixed;top:0;left:0;right:0;z-index:9999;background:#22c55e;color:#000;padding:10px 16px;display:none;align-items:center;justify-content:center;gap:12px;font-size:13px;font-weight:700;box-shadow:0 2px 12px rgba(0,0,0,.3);">
-  ✨ App updated!
-  <button onclick="window.location.reload()" style="background:#000;color:#22c55e;border:none;border-radius:6px;padding:4px 12px;font-size:12px;font-weight:700;cursor:pointer;">Reload now</button>
-  <button onclick="this.parentElement.style.display='none'" style="background:none;border:none;color:#000;font-size:18px;cursor:pointer;line-height:1;margin-left:4px;">×</button>
+<div id="update-banner" style="display:none;position:fixed;top:0;left:0;right:0;z-index:9999;background:var(--brand-gradient);color:#fff;padding:10px 16px;align-items:center;justify-content:center;gap:12px;font-size:13px;font-weight:700;box-shadow:0 2px 14px rgba(0,0,0,.28);">
+  ✨ A new version of Arete is ready
+  <button onclick="window.location.reload()" style="background:#fff;color:var(--accent);border:none;border-radius:8px;padding:5px 14px;font-size:12px;font-weight:700;cursor:pointer;">Reload</button>
+  <button onclick="this.parentElement.style.display='none'" style="background:none;border:none;color:rgba(255,255,255,.85);font-size:18px;cursor:pointer;line-height:1;margin-left:2px;">×</button>
 </div>
 
 <!-- INSTALL BANNER -->

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "display": "standalone",
   "display_override": ["standalone", "minimal-ui"],
   "background_color": "#0a0a0f",
-  "theme_color": "#8b7cff",
+  "theme_color": "#5a49e0",
   "orientation": "portrait-primary",
   "categories": ["productivity", "utilities"],
   "prefer_related_applications": false,


### PR DESCRIPTION
Follow-up brand-consistency pass after the Arete rebrand.

- **Update/reload banner**: was green and off-brand → now the Arete indigo gradient with white text, reworded to *"A new version of Arete is ready"*. This is the banner shown when the app updates.
- **theme-color**: the dark value was a stray blue (`#58a6ff`) → now `light=#f7f6f3` / `dark=#0a0a0f` (the real backgrounds); static meta set to the splash bg to avoid a violet flash before `applyTheme` runs.
- **manifest `theme_color`** → brand indigo (`#5a49e0`).
- Replaced old-violet rgba glows/shadows (body ambient, primary buttons, FAB, command palette, auth-gate, splash, swipe, shareable progress card) with the indigo brand rgb.
- Shareable progress-card ring stroke → brand indigo.

Semantic colors intentionally left intact: the deep-work/info blue (`#58a6ff`) used across charts, and the "wisdom" life-area / mid-progress hues — those are functional scales, not brand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_