### PR TITLE
Landing growth: analytics, SEO foundation, and comparison table

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -19,6 +19,11 @@
 <meta name="twitter:title" content="Arete · Command your day. Quiet your mind.">
 <meta name="twitter:description" content="The calm, keyboard-fast home for everything you have to do.">
 <meta name="twitter:image" content="https://task-management-beige-eight.vercel.app/og-image.png">
+<link rel="sitemap" type="application/xml" href="/sitemap.xml">
+<!-- Structured data for rich search results (honest: no fabricated ratings) -->
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Arete","applicationCategory":"ProductivityApplication","operatingSystem":"Web, iOS, Android","url":"https://task-management-beige-eight.vercel.app/","description":"The calm, keyboard-fast home for everything you have to do. Superhuman speed for your tasks, Notion depth for your goals, and an AI that clears your inbox and plans your day.","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"featureList":["Keyboard-fast natural-language capture","AI inbox triage and day planning","Goals, habits and weekly reviews","Offline-first, syncs across devices","Free to start, no account needed"],"author":{"@type":"Person","name":"Panos"}}
+</script>
 <script>
 /* Front-door router: returning users and auth callbacks never see the pitch. */
 (function(){
@@ -268,6 +273,20 @@
   .tpl h3{font-size:16px;font-weight:700;margin-bottom:5px;color:#211f1a}
   .tpl p{font-size:13.5px;color:var(--muted);line-height:1.5}
 
+  /* ── Comparison table ── */
+  .ctable-wrap{margin-top:48px;overflow-x:auto;border:1px solid var(--border);border-radius:18px;background:var(--surface);box-shadow:0 1px 2px rgba(42,38,32,.03)}
+  .ctable{width:100%;border-collapse:collapse;min-width:640px}
+  .ctable th,.ctable td{padding:16px 18px;text-align:center;font-size:15px;border-bottom:1px solid var(--border)}
+  .ctable thead th{font-size:13px;font-weight:700;color:var(--muted);letter-spacing:.02em}
+  .ctable thead th.hl{color:var(--accent)}
+  .ctable tbody td:first-child,.ctable thead th:first-child{text-align:left;font-weight:600;color:var(--text);width:38%}
+  .ctable .hl{background:var(--accent-soft)}
+  .ctable tbody tr:last-child td{border-bottom:none}
+  .ctable .y{color:#3fa66a;font-weight:800}
+  .ctable .n{color:#cfc9bf;font-weight:700}
+  .ctable .p{color:var(--faint);font-weight:700}
+  .ctable-legend{text-align:center;color:var(--faint);font-size:12.5px;margin-top:14px}
+
   @media(max-width:760px){
     .nav-links{display:none}
     .posbar-in,.compare,.tpl-grid{grid-template-columns:1fr}
@@ -497,6 +516,28 @@
   </div>
 </section>
 
+<section class="band" id="compare">
+  <div class="wrap">
+    <div class="kicker">See how it compares</div>
+    <h2>The depth without the drag</h2>
+    <p class="lead">How Arete stacks up against the two things you're probably using now.</p>
+    <div class="ctable-wrap">
+      <table class="ctable">
+        <thead><tr><th></th><th>Flat to-do apps</th><th class="hl">Arete</th><th>All-in-one workspaces</th></tr></thead>
+        <tbody>
+          <tr><td>Keyboard-fast capture (⌘K)</td><td><span class="p">partial</span></td><td class="hl"><span class="y">✓</span></td><td><span class="n">✗</span></td></tr>
+          <tr><td>Goals, habits &amp; weekly reviews</td><td><span class="n">✗</span></td><td class="hl"><span class="y">✓</span></td><td><span class="y">✓</span></td></tr>
+          <tr><td>AI triage &amp; plan-my-day</td><td><span class="n">✗</span></td><td class="hl"><span class="y">✓</span></td><td><span class="p">partial</span></td></tr>
+          <tr><td>Works fully offline</td><td><span class="p">partial</span></td><td class="hl"><span class="y">✓</span></td><td><span class="n">✗</span></td></tr>
+          <tr><td>Zero setup, start in seconds</td><td><span class="y">✓</span></td><td class="hl"><span class="y">✓</span></td><td><span class="n">✗</span></td></tr>
+          <tr><td>Stays calm, not a second job</td><td><span class="y">✓</span></td><td class="hl"><span class="y">✓</span></td><td><span class="n">✗</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="ctable-legend">Honest take from someone who used all three. Your mileage may vary, and that's fine.</div>
+  </div>
+</section>
+
 <section class="band trust-band" id="trust">
   <div class="wrap">
     <div class="kicker">Trust &amp; privacy</div>
@@ -650,6 +691,41 @@
     }, {threshold:0.3});
     io.observe(wrap);
   } else { loop(); }
+})();
+</script>
+<script>
+/* ── Landing analytics ─────────────────────────────────────────────────────
+   Paste the SAME PostHog key you set in index.html's APP_CONFIG.posthogKey.
+   Same key + same origin means the landing → signup funnel connects on its own.
+   Leave blank to disable; every track() call becomes a silent no-op.          */
+(function(){
+  var POSTHOG_KEY  = '';                        // e.g. 'phc_xxxxxxxx'
+  var POSTHOG_HOST = 'https://us.i.posthog.com';
+  function track(ev,props){ try{ if(window.posthog && posthog.capture) posthog.capture(ev, props||{}); }catch(e){} }
+  if(POSTHOG_KEY){
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    try{ posthog.init(POSTHOG_KEY,{api_host:POSTHOG_HOST,persistence:'localStorage',autocapture:false,capture_pageview:true}); track('landing_view',{ref:(new URLSearchParams(location.search)).get('ref')||''}); }catch(e){}
+  }
+  // Which CTA drives signups (hero / final / nav / templates / how / footer)
+  document.addEventListener('click',function(e){
+    var a = e.target && e.target.closest ? e.target.closest('a.app-link') : null;
+    if(!a) return;
+    var loc = a.closest('nav') ? 'nav' : a.closest('.final') ? 'final' : a.closest('.hero') ? 'hero'
+            : a.closest('#templates') ? 'templates' : a.closest('#how') ? 'how' : a.closest('footer') ? 'footer' : 'body';
+    track('landing_cta_click',{location:loc, label:(a.textContent||'').trim().slice(0,40)});
+  }, true);
+  // How far people read
+  var m={25:0,50:0,75:0,100:0};
+  window.addEventListener('scroll',function(){
+    var doc=document.documentElement, hgt=doc.scrollHeight-window.innerHeight;
+    var pct = hgt>0 ? Math.round(window.scrollY/hgt*100) : 100;
+    [25,50,75,100].forEach(function(k){ if(pct>=k && !m[k]){ m[k]=1; track('landing_scroll',{depth:k}); } });
+  }, {passive:true});
+  // Did the hero demo actually get seen
+  if('IntersectionObserver' in window){
+    var d=document.querySelector('.demo-wrap');
+    if(d){ var seen=false; new IntersectionObserver(function(en){ en.forEach(function(x){ if(x.isIntersecting && !seen){ seen=true; track('landing_demo_seen',{}); } }); },{threshold:0.4}).observe(d); }
+  }
 })();
 </script>
 </body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://task-management-beige-eight.vercel.app/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://task-management-beige-eight.vercel.app/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Makes the landing measurable and discoverable, and adds decision-stage content.

- **Analytics (PostHog):** tracks `landing_view`, `landing_cta_click` (which CTA — hero/final/nav/templates/…), `landing_scroll` depth, and `landing_demo_seen`. Uses the **same key as the app**, so the landing → signup funnel connects automatically. Gated on a key you paste into `POSTHOG_KEY`; blank = silent no-op.
- **SEO foundation:** JSON-LD `SoftwareApplication` structured data (honest — no fabricated ratings), plus `sitemap.xml` and `robots.txt` so search engines can index the site.
- **Comparison table** — *"The depth without the drag"* — an honest Arete vs flat to-do apps vs all-in-one workspaces feature grid to capture "researching alternatives" search intent.

All CSP-safe (PostHog hosts already allow-listed). No em dashes. The hero demo and auth router are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwoyEMAsmmHjTY4L7i48of)_